### PR TITLE
FIX: Updated paths of some dependencies

### DIFF
--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -275,7 +275,7 @@ Function InstModeSelectionPage_Leave
 
 			; Execute fixed, embedded 06 uninstaller
 			ClearErrors
-			File "NSISPlugins\uninstaller_06.exe"
+			File "__NSIS_PLUGINS__\uninstaller_06.exe"
 			ExecWait '"$INSTDIR\uninstaller_06.exe" /S _?=$INSTDIR'
 			IfErrors error_uninstalling_06
 			Goto uninstall_06_complete

--- a/hspy_bundle/configure_installer.py
+++ b/hspy_bundle/configure_installer.py
@@ -30,7 +30,7 @@ def get_current_hyperspy_version():
 def download_hyperspy_license():
     from urllib import urlretrieve
     urlretrieve("https://raw.github.com/hyperspy/hyperspy/master/COPYING.txt",
-                os.path.join(os.path.dirname(__file__), "COPYING.txt"))
+                "COPYING.txt")
 
 
 def create_delete_macro(path, name, add_uninstaller=True):
@@ -182,7 +182,7 @@ if __name__ == "__main__":
         hspy_version = sys.argv[3]
     else:
         hspy_version = get_current_hyperspy_version()
-    if not os.path.exists(os.path.join(__file__, 'COPYING.txt')):
+    if not os.path.exists('COPYING.txt'):
         download_hyperspy_license()
     p = HSpyBundleInstaller(bundle_dir, hspy_version, arch)
     p.create_delete_macros()


### PR DESCRIPTION
Revert one of the changes in #3, and fix the path of the precompiled 0.6 uninstaller.