### PR TITLE
Release with py37

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,8 +65,11 @@ before_deploy:
   - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/env.bat"
   # Give info about python vesion and compiler used to compile the python
   - "%CMD_IN_ENV% python.exe -c \"import sys; print(sys.version)\""
+
+  # Use matplotlib 2.2.3 until tests are not compatible with 3.0
+  - "%CMD_IN_ENV% pip install matplotlib==2.2.3 pytest-mpl"
   # Use a specific branch of hyperspy on github
-  - "%CMD_IN_ENV% pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_patch.zip#egg=hyperspy[all]"
+  - "%CMD_IN_ENV% pip install https://github.com/ericpre/hyperspy/archive/fix_cleanup_decorator_plot_testing.zip#egg=hyperspy[all]"
   # Use a release version of hyperspy
   #- "%CMD_IN_ENV% pip install hyperspy[all]"
   - "%CMD_IN_ENV% pip install start_jupyter_cm"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,11 @@ before_deploy:
   - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/env.bat"
   # Give info about python vesion and compiler used to compile the python
   - "%CMD_IN_ENV% python.exe -c \"import sys; print(sys.version)\""
-  - "%CMD_IN_ENV% pip install hyperspy[all] start_jupyter_cm"
+  # Use a specific branch of hyperspy on github
+  - "%CMD_IN_ENV% pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_patch.zip#egg=hyperspy[all]"
+  # Use a release version of hyperspy
+  #- "%CMD_IN_ENV% pip install hyperspy[all]"
+  - "%CMD_IN_ENV% pip install start_jupyter_cm"
   # Try to run twice as workaround for permission error (for now, we keep master to test the bundle)
   - "%CMD_IN_ENV% pip install https://github.com/hyperspy/hyperspyUI/archive/master.zip || pip install https://github.com/hyperspy/hyperspyUI/archive/master.zip"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,28 +11,28 @@ environment:
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
      - PYTHON: "C:\\Miniconda36"
-       PYTHON_VERSION_SHORT: "3.6"
+       PYTHON_VERSION_SHORT: "36"
        PYTHON_VERSION: "3.6.6"
        PYTHON_ARCH: "32"
        WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython32-3.6.6.2Qt5.exe'
        WP_CRC: 'af9301f4748f7443732c6fc2ecab0e25e0109d5fda623d686e4371d015eb7be3'
 
      - PYTHON: "C:\\Miniconda36-x64"
-       PYTHON_VERSION_SHORT: "3.6"
+       PYTHON_VERSION_SHORT: "36"
        PYTHON_VERSION: "3.6.6"
        PYTHON_ARCH: "64"
        WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython64-3.6.6.2Qt5.exe'
        WP_CRC: '0007085df58ad4e5749e6d3fc43ce49688ca15a77abea615d36770b2f7ec1ba3'
 
      - PYTHON: "C:\\Miniconda37"
-       PYTHON_VERSION_SHORT: "3.7"
+       PYTHON_VERSION_SHORT: "37"
        PYTHON_VERSION: "3.7.0"
        PYTHON_ARCH: "32"
        WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython32-3.7.0.2.exe'
        WP_CRC: '4516e09e671d027d50f0c160ad9d2fe8528f610970d38a20093fbdcc731b0735'
 
      - PYTHON: "C:\\Miniconda37-x64"
-       PYTHON_VERSION_SHORT: "3.7"
+       PYTHON_VERSION_SHORT: "37"
        PYTHON_VERSION: "3.7.0"
        PYTHON_ARCH: "64"
        WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython64-3.7.0.2.exe'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,30 +10,16 @@ environment:
 
     # Pre-installed Python versions, which Appveyor may upgrade to
     # a later point release.
-     - PYTHON: "C:\\Miniconda35"
-       PYTHON_VERSION: "3.5.x"
-       PYTHON_MAJOR: 3
-       PYTHON_ARCH: "32"
-       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.9.20171031/WinPython-32bit-3.5.4.1Qt5.exe'
-       WP_CRC: 'e58b0c86fc4e6ae4fe3f9f467008fd4e3447b5f35b7ad689ab01cdc93733d19e'
-
-     - PYTHON: "C:\\Miniconda35-x64"
-       PYTHON_VERSION: "3.5.x"
-       PYTHON_MAJOR: 3
-       PYTHON_ARCH: "64"
-       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.9.20171031/WinPython-64bit-3.5.4.1Qt5.exe'
-       WP_CRC: 'e522c8adfbd9c967fa2f692d3c313fec1f0e53724b4651ea9e969228532a9586'
-
      - PYTHON: "C:\\Miniconda36"
-       PYTHON_VERSION: "3.6.x"
-       PYTHON_MAJOR: 3
+       PYTHON_VERSION_SHORT: "3.6"
+       PYTHON_VERSION: "3.6.3"
        PYTHON_ARCH: "32"
        WP_URL: 'https://github.com/winpython/winpython/releases/download/1.9.20171031/WinPython-32bit-3.6.3.0Qt5.exe'
        WP_CRC: '56259865127c3f802f1eca29528f2676317cad2fd6573ce516fc35b4441a1d3c'
 
      - PYTHON: "C:\\Miniconda36-x64"
-       PYTHON_VERSION: "3.6.x"
-       PYTHON_MAJOR: 3
+       PYTHON_VERSION_SHORT: "3.6"
+       PYTHON_VERSION: "3.6.3"
        PYTHON_ARCH: "64"
        WP_URL: 'https://github.com/winpython/winpython/releases/download/1.9.20171031/WinPython-64bit-3.6.3.0Qt5.exe'
        WP_CRC: 'a5efea23ede143fdacab60b8db95835de25c0173bd0d9fd53d5952648bde69b9'
@@ -54,7 +40,7 @@ before_deploy:
   # Download WinPython installer if not cached
   - ps: Add-AppveyorMessage "Installing WinPython..."
   - "SET WP_INSTDIR=%USERPROFILE%\\wpdir\\WinPython-%PYTHON_ARCH%\\"
-  - "SET WP_EXE=%USERPROFILE%/wpdir/WinPython%PYTHON_MAJOR%-%PYTHON_ARCH%bit.exe"
+  - "SET WP_EXE=%USERPROFILE%/wpdir/WinPython3-%PYTHON_ARCH%bit.exe"
   - "mkdir %USERPROFILE%\\wpdir"
   - ps: appveyor DownloadFile $Env:WP_URL -FileName $Env:WP_EXE
   - ps: Write-Output (Get-FileHash $Env:WP_EXE)
@@ -90,10 +76,9 @@ before_deploy:
   - "ls"
   - ps: Add-AppveyorMessage "Installer created! Run tests in Winpython environment..."
   # Re-run tests in WinPython environment
-  - ps: if($Env:PYTHON_VERSION -eq "3.5.x") {$Env:PY_VERSION="3.5.4"} else {$Env:PY_VERSION="3.6.3"}
-  - ps: if($Env:PYTHON_ARCH -eq "64") {$Env:PYTHON_DIR_NAME="python-"+$Env:PY_VERSION+".amd64"} else {$Env:PYTHON_DIR_NAME="python-"+$Env:PY_VERSION}
+  - ps: if($Env:PYTHON_ARCH -eq "64") {$Env:PYTHON_DIR_NAME="python-"+$Env:PYTHON_VERSION+".amd64"} else {$Env:PYTHON_DIR_NAME="python-"+$Env:PYTHON_VERSION}
   # Use hyperspy-bundle tag as version name
-  - "SET BUNDLE_INST_NAME=HyperSpy-Bundle-%APPVEYOR_REPO_TAG_NAME%-%PY_VERSION%-%PYTHON_ARCH%bit.exe"
+  - "SET BUNDLE_INST_NAME=HyperSpy-Bundle-%APPVEYOR_REPO_TAG_NAME%-py%PYTHON_VERSION_SHORT%-%PYTHON_ARCH%bit.exe"
   - "ren HyperSpy-Bundle-%APPVEYOR_REPO_TAG_NAME%-%PYTHON_ARCH%bit.exe %BUNDLE_INST_NAME%"
   - "SET HYPERSPY_DIR=%WP_INSTDIR%\\%PYTHON_DIR_NAME%\\Lib\\site-packages\\hyperspy"
   - ps: py.test --mpl $Env:HYPERSPY_DIR

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,8 +80,8 @@ before_deploy:
   # Give info about python vesion and compiler used to compile the python
   - "%CMD_IN_ENV% python.exe -c \"import sys; print(sys.version)\""
 
-  # Use matplotlib 2.2.3 until tests are not compatible with 3.0
-  - "%CMD_IN_ENV% pip install matplotlib==2.2.3 pytest-mpl"
+  # Remove typing to run tests (winpython bug?) typing is only requires for python<3.5
+  - "%CMD_IN_ENV% pip uninstall -y typing"
   # Use a specific branch of hyperspy on github
   - "%CMD_IN_ENV% pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
   # Use a release version of hyperspy
@@ -97,6 +97,8 @@ before_deploy:
   - "ls"
   - ps: Add-AppveyorMessage "Installer created! Run tests in Winpython environment..."
   # Re-run tests in WinPython environment
+  # Use matplotlib 2.2.3 until tests are not compatible with 3.0
+  - "%CMD_IN_ENV% pip install matplotlib==2.2.3 pytest-mpl"
   - ps: if($Env:PYTHON_ARCH -eq "64") {$Env:PYTHON_DIR_NAME="python-"+$Env:PYTHON_VERSION+".amd64"} else {$Env:PYTHON_DIR_NAME="python-"+$Env:PYTHON_VERSION}
   # Use hyperspy-bundle tag as version name
   - "SET BUNDLE_INST_NAME=HyperSpy-Bundle-%APPVEYOR_REPO_TAG_NAME%-py%PYTHON_VERSION_SHORT%-%PYTHON_ARCH%bit.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ before_deploy:
   # Use matplotlib 2.2.3 until tests are not compatible with 3.0
   - "%CMD_IN_ENV% pip install matplotlib==2.2.3 pytest-mpl"
   # Use a specific branch of hyperspy on github
-  - "%CMD_IN_ENV% pip install https://github.com/ericpre/hyperspy/archive/fix_cleanup_decorator_plot_testing.zip#egg=hyperspy[all]"
+  - "%CMD_IN_ENV% pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
   # Use a release version of hyperspy
   #- "%CMD_IN_ENV% pip install hyperspy[all]"
   - "%CMD_IN_ENV% pip install start_jupyter_cm"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,9 +85,9 @@ before_deploy:
   # tqdm RuntimeError when running samfire tests, see https://github.com/hyperspy/hyperspy/issues/2077
   - "%CMD_IN_ENV% pip install tqdm==4.24"
   # Use a specific branch of hyperspy on github
-  - "%CMD_IN_ENV% pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
+  #- "%CMD_IN_ENV% pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
   # Use a release version of hyperspy
-  #- "%CMD_IN_ENV% pip install hyperspy[all]"
+  - "%CMD_IN_ENV% pip install hyperspy[all]"
   - "%CMD_IN_ENV% pip install start_jupyter_cm"
   # Try to run twice as workaround for permission error (for now, we keep master to test the bundle)
   - "%CMD_IN_ENV% pip install https://github.com/hyperspy/hyperspyUI/archive/master.zip || pip install https://github.com/hyperspy/hyperspyUI/archive/master.zip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,20 @@ environment:
        WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython64-3.6.6.2Qt5.exe'
        WP_CRC: '0007085df58ad4e5749e6d3fc43ce49688ca15a77abea615d36770b2f7ec1ba3'
 
+     - PYTHON: "C:\\Miniconda37"
+       PYTHON_VERSION_SHORT: "3.7"
+       PYTHON_VERSION: "3.7.0"
+       PYTHON_ARCH: "32"
+       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython32-3.7.0.2.exe'
+       WP_CRC: '4516e09e671d027d50f0c160ad9d2fe8528f610970d38a20093fbdcc731b0735'
+
+     - PYTHON: "C:\\Miniconda37-x64"
+       PYTHON_VERSION_SHORT: "3.7"
+       PYTHON_VERSION: "3.7.0"
+       PYTHON_ARCH: "64"
+       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython64-3.7.0.2.exe'
+       WP_CRC: '506376156017929982179381bf449841fb17041f0d95ea03ed4c8add871e8f45'
+
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
   - "ECHO %APPVEYOR_BUILD_FOLDER%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,17 +12,17 @@ environment:
     # a later point release.
      - PYTHON: "C:\\Miniconda36"
        PYTHON_VERSION_SHORT: "3.6"
-       PYTHON_VERSION: "3.6.3"
+       PYTHON_VERSION: "3.6.6"
        PYTHON_ARCH: "32"
-       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.9.20171031/WinPython-32bit-3.6.3.0Qt5.exe'
-       WP_CRC: '56259865127c3f802f1eca29528f2676317cad2fd6573ce516fc35b4441a1d3c'
+       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython32-3.6.6.2Qt5.exe'
+       WP_CRC: 'af9301f4748f7443732c6fc2ecab0e25e0109d5fda623d686e4371d015eb7be3'
 
      - PYTHON: "C:\\Miniconda36-x64"
        PYTHON_VERSION_SHORT: "3.6"
-       PYTHON_VERSION: "3.6.3"
+       PYTHON_VERSION: "3.6.6"
        PYTHON_ARCH: "64"
-       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.9.20171031/WinPython-64bit-3.6.3.0Qt5.exe'
-       WP_CRC: 'a5efea23ede143fdacab60b8db95835de25c0173bd0d9fd53d5952648bde69b9'
+       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython64-3.6.6.2Qt5.exe'
+       WP_CRC: '0007085df58ad4e5749e6d3fc43ce49688ca15a77abea615d36770b2f7ec1ba3'
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,6 +82,8 @@ before_deploy:
 
   # Remove typing to run tests (winpython bug?) typing is only requires for python<3.5
   - "%CMD_IN_ENV% pip uninstall -y typing"
+  # tqdm RuntimeError when running samfire tests, see https://github.com/hyperspy/hyperspy/issues/2077
+  - "%CMD_IN_ENV% pip install tqdm==4.24"
   # Use a specific branch of hyperspy on github
   - "%CMD_IN_ENV% pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
   # Use a release version of hyperspy

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -22,13 +22,12 @@
 !define WINPYTHON_PATH "__WINPYTHON_PATH__"
 !define PYTHON_FOLDER "__PYTHON_FOLDER__"
 !define S_NAME "HyperSpy-Bundle-${APPVERSION}-${ARCHITECTURE}"
-!define APP_REL_INSTDIR "${APPNAME} ${APPVERSION}"
-!define S_DEFINSTDIR_USER "$PROFILE\${APP_REL_INSTDIR}"
-!define S_DEFINSTDIR_PORTABLE "$DOCUMENTS\${APP_REL_INSTDIR}"
+!define S_DEFINSTDIR_USER "$PROFILE\${APPNAME}"
+!define S_DEFINSTDIR_PORTABLE "$DOCUMENTS\${APPNAME}"
 !ifdef CL64
-	!define S_DEFINSTDIR_ADMIN "$ProgramFiles64\${APP_REL_INSTDIR}"
+	!define S_DEFINSTDIR_ADMIN "$ProgramFiles64\${APPNAME}"
 !else
-	!define S_DEFINSTDIR_ADMIN "$ProgramFiles\${APP_REL_INSTDIR}"
+	!define S_DEFINSTDIR_ADMIN "$ProgramFiles\${APPNAME}"
 !endif
 !define APP_INSTDIR "$INSTDIR"
 !define UNINSTALLER_FULLPATH "${APP_INSTDIR}\Uninstall_Hyperspy_Bundle.exe"
@@ -210,6 +209,12 @@ Function InstModeSelectionPage_Leave
 	; push $0 ;put back all users hwnd
 	${NSD_GetState} $0 $9
 	${NSD_GetState} $1 $8
+
+	StrLen $INSTDIRLEN $INSTDIR
+	${If} $INSTDIRLEN > 35 ${AndIfNot} ${AtLeastWin8}
+		MessageBox MB_OK "Installation path should be shorter than 35 characters."
+	${EndIf}
+
 	${If} $8 = 1
 		!insertmacro SetInstMode 1
 	${ElseIf} $9 = 1
@@ -292,7 +297,7 @@ FunctionEnd
 
 Function .onVerifyInstDir
     ${If} ${FileExists} $InstDir
-          StrCpy $InstDir "$INSTDIR\${APP_REL_INSTDIR}"
+          StrCpy $InstDir "$INSTDIR\${APPNAME}"
     ${EndIf}
 FunctionEnd
 

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -303,7 +303,6 @@ SectionIn RO
 	; Include default MPL RC file
 	SetOutPath "${APP_INSTDIR}"
 	File /r "${WINPYTHON_PATH}\*"
-	Exec 'cmd.exe /C ""${APP_INSTDIR}\WinPython Command Prompt.exe" "jupyter nbextension enable --py --sys-prefix widgetsnbextension""'
 	${If} $InstMode = 2
 	; Create right-click context menu entries for Hyperspy Here
 		Exec 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" add"'
@@ -314,6 +313,7 @@ SectionIn RO
 		CreateDirectory "$SMPROGRAMS\${APPNAME}"
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\HyperSpyUI.lnk" "${APP_INSTDIR}\hspy_scripts\hyperspyui.bat" "" "${APP_INSTDIR}\${PYTHON_FOLDER}\Lib\site-packages\hyperspyui\images\icon\hyperspy.ico" 0
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\Jupyter Notebook.lnk" "${APP_INSTDIR}\hspy_scripts\jupyter_notebook.bat" "--notebook-dir=$\"%HOMEPATH%$\"" "${APP_INSTDIR}\${PYTHON_FOLDER}\Lib\site-packages\start_jupyter_cm\icons\jupyter.ico" 0
+		CreateShortCut "$SMPROGRAMS\${APPNAME}\Jupyter Lab.lnk" "${APP_INSTDIR}\hspy_scripts\jupyter_lab.bat" "--notebook-dir=$\"%HOMEPATH%$\"" "${APP_INSTDIR}\${PYTHON_FOLDER}\Lib\site-packages\start_jupyter_cm\icons\jupyter.ico" 0
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\Jupyter QtConsole.lnk" "${APP_INSTDIR}\hspy_scripts\jupyter_qtconsole.bat" "$\"%HOMEPATH%$\"" "${APP_INSTDIR}\${PYTHON_FOLDER}\Lib\site-packages\start_jupyter_cm\icons\jupyter-qtconsole.ico" 0
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\WinPython prompt.lnk" "${APP_INSTDIR}\hspy_scripts\cmd.bat" "" "${APP_INSTDIR}\hspy_scripts\cmd.ico" 0
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\Python prompt.lnk" "${APP_INSTDIR}\hspy_scripts\python.bat" "" "${APP_INSTDIR}\hspy_scripts\python.ico" 0
@@ -365,6 +365,7 @@ Section "Uninstall"
 	Delete "$SMPROGRAMS\${APPNAME}\HyperSpyUI.lnk"
 	Delete "$SMPROGRAMS\${APPNAME}\Jupyter Notebook.lnk"
 	Delete "$SMPROGRAMS\${APPNAME}\Jupyter QtConsole.lnk"
+	Delete "$SMPROGRAMS\${APPNAME}\Jupyter Lab.lnk"
 	Delete "$SMPROGRAMS\${APPNAME}\WinPython prompt.lnk"
 	Delete "$SMPROGRAMS\${APPNAME}\Python prompt.lnk"
 	Delete "$SMPROGRAMS\${APPNAME}\Spyder IDE.lnk"

--- a/hspy_bundle/configure_installer.py
+++ b/hspy_bundle/configure_installer.py
@@ -9,6 +9,10 @@ import shutil
 
 import winpython.wppm
 
+LAB_BAT = u"""@echo off
+call "%~dp0env.bat"
+jupyter-lab.exe %*
+"""
 
 NOTEBOOK_BAT = u"""@echo off
 call "%~dp0env.bat"
@@ -263,10 +267,10 @@ class HSpyBundleInstaller:
                              hspy_scripts)
             for f, script in zip(
                     ("jupyter_qtconsole.bat", "jupyter_notebook.bat",
-                     "spyder.bat", "python.bat", "cmd.bat", "hyperspyui.bat",
-                     "jupyter_cm.bat"),
-                    (QTCONSOLE_BAT, NOTEBOOK_BAT, SPYDER_BAT, PYTHON_BAT,
-                     CMD_BAT, HSPYUI_BAT, JUPYTER_CM_BAT)):
+                     "jupyter_lab.bat", "spyder.bat", "python.bat", 
+                     "cmd.bat", "hyperspyui.bat", "jupyter_cm.bat"),
+                    (QTCONSOLE_BAT, NOTEBOOK_BAT, LAB_BAT, SPYDER_BAT, 
+                     PYTHON_BAT, CMD_BAT, HSPYUI_BAT, JUPYTER_CM_BAT)):
                 with io.open(os.path.join(hspy_scripts, f), 'w',
                              newline='\r\n', errors="ignore") as f:
                     f.write(script)

--- a/hspy_bundle/configure_installer.py
+++ b/hspy_bundle/configure_installer.py
@@ -172,9 +172,12 @@ class HSpyBundleInstaller:
         if not isinstance(arch, (list, tuple)):
             arch = (arch,)
         self.arch = arch
-        self.wppath = dict((
-            (a, glob(os.path.join(dist_path, "WinPython-%s*" % a))[0])
-            for a in arch))
+        try:
+            self.wppath = dict((
+                (a, glob(os.path.join(dist_path, "WinPython-%s*" % a))[0])
+                for a in arch))
+        except IndexError:
+            raise RuntimeError("No Winpython distribution can be found.")
         self.distributions = dict((
             (a, winpython.wppm.Distribution(
                 self.get_full_paths("python-*", a)))


### PR DESCRIPTION
Same as #33 but with python 3.7.

- [x] update to last winpython,
- [x] set tqdm version to 4.24 to avoid issue with https://github.com/hyperspy/hyperspy/issues/2077,
- [x] replace python 3.5 with 3.7,
- [x] remove typing package to avoid python 3.7, see https://ci.appveyor.com/project/ericpre/hyperspy-bundle/builds/19660402,
- [x] fix #23,
- [x] fix #31,
- [x] ready for review.
