### PR TITLE
Compile bytecode at the end of the installation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,22 +8,6 @@ environment:
 
   matrix:
 
-    # Pre-installed Python versions, which Appveyor may upgrade to
-    # a later point release.
-     - PYTHON: "C:\\Miniconda36"
-       PYTHON_VERSION_SHORT: "36"
-       PYTHON_VERSION: "3.6.6"
-       PYTHON_ARCH: "32"
-       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython32-3.6.6.2Qt5.exe'
-       WP_CRC: 'af9301f4748f7443732c6fc2ecab0e25e0109d5fda623d686e4371d015eb7be3'
-
-     - PYTHON: "C:\\Miniconda36-x64"
-       PYTHON_VERSION_SHORT: "36"
-       PYTHON_VERSION: "3.6.6"
-       PYTHON_ARCH: "64"
-       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython64-3.6.6.2Qt5.exe'
-       WP_CRC: '0007085df58ad4e5749e6d3fc43ce49688ca15a77abea615d36770b2f7ec1ba3'
-
      - PYTHON: "C:\\Miniconda37"
        PYTHON_VERSION_SHORT: "37"
        PYTHON_VERSION: "3.7.0"

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -315,6 +315,7 @@ SectionIn RO
 	; Include default MPL RC file
 	SetOutPath "${APP_INSTDIR}"
 	File /r "${WINPYTHON_PATH}\*"
+	Exec 'cmd.exe /C "${APP_INSTDIR}\hspy_scripts\compile_all.bat"'
 	${If} $InstMode = 2
 	; Create right-click context menu entries for Hyperspy Here
 		Exec 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" add"'

--- a/hspy_bundle/configure_installer.py
+++ b/hspy_bundle/configure_installer.py
@@ -74,6 +74,14 @@ if [%1]==[remove] cmd.exe /c "jupyter_context-menu_remove"
 
 """
 
+COMPILE_ALL_BAT = u"""@echo off
+call "%~dp0env.bat"
+set "LIB_DIR=%WINPYDIR%\Lib"
+cd %LIB_DIR%
+cmd.exe /c "python -m compileall ."
+
+"""
+
 
 def get_nsis_template_path():
     return os.path.join(os.path.abspath(os.path.dirname(__file__)),
@@ -271,9 +279,11 @@ class HSpyBundleInstaller:
             for f, script in zip(
                     ("jupyter_qtconsole.bat", "jupyter_notebook.bat",
                      "jupyter_lab.bat", "spyder.bat", "python.bat", 
-                     "cmd.bat", "hyperspyui.bat", "jupyter_cm.bat"),
+                     "cmd.bat", "hyperspyui.bat", "jupyter_cm.bat",
+                     "compile_all.bat"),
                     (QTCONSOLE_BAT, NOTEBOOK_BAT, LAB_BAT, SPYDER_BAT, 
-                     PYTHON_BAT, CMD_BAT, HSPYUI_BAT, JUPYTER_CM_BAT)):
+                     PYTHON_BAT, CMD_BAT, HSPYUI_BAT, JUPYTER_CM_BAT,
+                     COMPILE_ALL_BAT)):
                 with io.open(os.path.join(hspy_scripts, f), 'w',
                              newline='\r\n', errors="ignore") as f:
                     f.write(script)


### PR DESCRIPTION
- [x] add `compile_all.bat` script to generate bytecode of python files in the LIB folder
- [x] run this script at the end of the installation,
- [x] ready for review.

IT makes the installation a bit longer but it solves the permission issue when installing with admin right.