### PR TITLE
New release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,25 +82,18 @@ before_deploy:
   - "SET BUNDLE_INST_NAME=HyperSpy-Bundle-%APPVEYOR_REPO_TAG_NAME%-py%PYTHON_VERSION_SHORT%-%PYTHON_ARCH%bit.exe"
   - "ren HyperSpy-Bundle-%APPVEYOR_REPO_TAG_NAME%-%PYTHON_ARCH%bit.exe %BUNDLE_INST_NAME%"
 
+  - ps: Add-AppveyorMessage "Pushing artefacts..."
+  - "appveyor PushArtifact %BUNDLE_INST_NAME%"
+  # Report checksums
+  - md5sum %BUNDLE_INST_NAME%
+  - sha256sum %BUNDLE_INST_NAME%
+
   - ps: Add-AppveyorMessage "Installer created! Run tests in Winpython environment..."
   # Re-run tests in WinPython environment
   # For hyperspy>1.4.1 remove matplotlib=2.2.3 and pytest=4.0.2
   - "pip install matplotlib==2.2.3 pytest==4.0.2 pytest-mpl pytest-qt"
   - "pytest --mpl --pyargs hyperspy"
   - "pytest --pyargs hyperspyui"
-  - ps: Add-AppveyorMessage "Tests finished! Pushing to GitHub..."
-  - "appveyor PushArtifact %BUNDLE_INST_NAME%"
-  # Report checksums
-  - md5sum %BUNDLE_INST_NAME%
-  - sha256sum %BUNDLE_INST_NAME%
-
-on_failure:
-  # In case, the tests fail, we still push the installer to debug the failure if necessary.
-  - "appveyor PushArtifact %BUNDLE_INST_NAME%"
-  # Report checksums
-  - md5sum %BUNDLE_INST_NAME%
-  - sha256sum %BUNDLE_INST_NAME%
-
 
 deploy:
   provider: GitHub

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,8 @@ before_deploy:
   #- "pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
   # Use a release version of hyperspy
   - "pip install hyperspy[all]"
-  - "pip install hyperspyui start_jupyter_cm"
+  - "pip install hyperspyui"
+  - "pip install https://github.com/ericpre/start_jupyter_cm/archive/master.zip"
   - "pip install atomap pixstem"
   - "pip install https://github.com/diffpy/diffpy.structure/archive/v3.0a2.zip"
   - "pip install https://github.com/pyxem/pyxem/archive/master.zip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,17 +10,17 @@ environment:
 
      - PYTHON: "C:\\Miniconda37"
        PYTHON_VERSION_SHORT: "37"
-       PYTHON_VERSION: "3.7.0"
+       PYTHON_VERSION: "3.7.2"
        PYTHON_ARCH: "32"
-       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython32-3.7.0.2.exe'
-       WP_CRC: '4516e09e671d027d50f0c160ad9d2fe8528f610970d38a20093fbdcc731b0735'
+       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.11.20190223/Winpython32-3.7.2.0.exe'
+       WP_CRC: '40a80d2fba1348da785bd97ee8de4e69c554c3d9dcd632b623a0f12e3ddb5ec0'
 
      - PYTHON: "C:\\Miniconda37-x64"
        PYTHON_VERSION_SHORT: "37"
-       PYTHON_VERSION: "3.7.0"
+       PYTHON_VERSION: "3.7.2"
        PYTHON_ARCH: "64"
-       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.10.20180827/WinPython64-3.7.0.2.exe'
-       WP_CRC: '506376156017929982179381bf449841fb17041f0d95ea03ed4c8add871e8f45'
+       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.11.20190223/Winpython64-3.7.2.0.exe'
+       WP_CRC: '3fb3ece2ba20fa903f15b642f5749a4517c2557788801197a981eea11ec21865'
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -42,7 +42,7 @@ before_deploy:
   - ps: appveyor DownloadFile $Env:WP_URL -FileName $Env:WP_EXE
   - ps: Write-Output (Get-FileHash $Env:WP_EXE)
   - ps: if ((Get-FileHash $Env:WP_EXE).Hash -ne $Env:WP_CRC) { exit(1) }
-  - ps: (& $Env:WP_EXE /S /D=$Env:WP_INSTDIR | Out-Null )
+  - ps: (& $Env:WP_EXE /VERYSILENT /DIR=$Env:WP_INSTDIR | Out-Null )
   - "ls %USERPROFILE%/wpdir"
   - "ls %WP_INSTDIR%"
 
@@ -57,13 +57,8 @@ before_deploy:
   # Give info about python vesion and compiler used to compile the python
   - "python.exe -c \"import sys; print(sys.version)\""
 
-  # Remove when updating winpython to >=2018-04
-  - "pip uninstall -y typing"
-  - "pip install --upgrade ipython ptpython jupyter-console"
-  # tqdm RuntimeError when running samfire tests, see https://github.com/hyperspy/hyperspy/issues/2077
-  - "pip install tqdm==4.24"
   # Use a specific branch of hyperspy on github
-  #- "%CMD_IN_ENV% pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
+  #- "pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
   # Use a release version of hyperspy
   - "pip install hyperspy[all]"
   - "pip install hyperspyui start_jupyter_cm"
@@ -76,22 +71,29 @@ before_deploy:
   - "%PYTHON%/python.exe -m hspy_bundle.configure_installer %USERPROFILE%/wpdir %PYTHON_ARCH% %APPVEYOR_REPO_TAG_NAME%"
   - "\"%NSIS_DIR%/makensis.exe\" /V3 NSIS_installer_script-%PYTHON_ARCH%bit.nsi"
   - "ls"
-  - ps: Add-AppveyorMessage "Installer created! Run tests in Winpython environment..."
-  # Re-run tests in WinPython environment
-  # Use matplotlib 2.2.3 until tests are not compatible with 3.0
-  - "pip install matplotlib==2.2.3 pytest-mpl"
-  - ps: if($Env:PYTHON_ARCH -eq "64") {$Env:PYTHON_DIR_NAME="python-"+$Env:PYTHON_VERSION+".amd64"} else {$Env:PYTHON_DIR_NAME="python-"+$Env:PYTHON_VERSION}
   # Use hyperspy-bundle tag as version name
   - "SET BUNDLE_INST_NAME=HyperSpy-Bundle-%APPVEYOR_REPO_TAG_NAME%-py%PYTHON_VERSION_SHORT%-%PYTHON_ARCH%bit.exe"
   - "ren HyperSpy-Bundle-%APPVEYOR_REPO_TAG_NAME%-%PYTHON_ARCH%bit.exe %BUNDLE_INST_NAME%"
-  - "SET HYPERSPY_DIR=%WP_INSTDIR%\\%PYTHON_DIR_NAME%\\Lib\\site-packages\\hyperspy"
-  - ps: py.test --mpl $Env:HYPERSPY_DIR
+
+  - ps: Add-AppveyorMessage "Installer created! Run tests in Winpython environment..."
+  # Re-run tests in WinPython environment
+  # For hyperspy>1.4.1 remove matplotlib=2.2.3 and pytest=4.0.2
+  - "pip install matplotlib==2.2.3 pytest==4.0.2 pytest-mpl pytest-qt"
+  - "pytest --mpl --pyargs hyperspy"
+  - "pytest --pyargs hyperspyui"
   - ps: Add-AppveyorMessage "Tests finished! Pushing to GitHub..."
   - "appveyor PushArtifact %BUNDLE_INST_NAME%"
+  # Report checksums
+  - md5sum %BUNDLE_INST_NAME%
+  - sha256sum %BUNDLE_INST_NAME%
 
 on_failure:
   # In case, the tests fail, we still push the installer to debug the failure if necessary.
   - "appveyor PushArtifact %BUNDLE_INST_NAME%"
+  # Report checksums
+  - md5sum %BUNDLE_INST_NAME%
+  - sha256sum %BUNDLE_INST_NAME%
+
 
 deploy:
   provider: GitHub

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,14 +57,16 @@ before_deploy:
   # Give info about python vesion and compiler used to compile the python
   - "python.exe -c \"import sys; print(sys.version)\""
 
+  # Remove some large package to get below the NSIS 2Gb limit
+  - "pip uninstall -y pygame plotnine holoviews pulp nltk datashader"
+
   # Use a specific branch of hyperspy on github
   #- "pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
   # Use a release version of hyperspy
   - "pip install hyperspy[all]"
   - "pip install hyperspyui"
   - "pip install https://github.com/ericpre/start_jupyter_cm/archive/master.zip"
-  - "pip install atomap pixstem"
-  - "pip install https://github.com/diffpy/diffpy.structure/archive/v3.0a2.zip"
+  - "pip install atomap pixstem diffpy.structure"
   - "pip install https://github.com/pyxem/pyxem/archive/master.zip"
 
   # Custom installer step

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,6 @@ environment:
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
   - "ECHO %APPVEYOR_BUILD_FOLDER%"
-  - "ECHO %CMD_IN_ENV%"
 
 install:
   - ps: Add-AppveyorMessage "Installing hyperspy-bundle..."
@@ -47,35 +46,30 @@ before_deploy:
   - "ls %USERPROFILE%/wpdir"
   - "ls %WP_INSTDIR%"
 
-  # Patch NSIS to allow longer strings
+  # Install UAC plugin
   - ps: Add-AppveyorMessage "Setting up WinPython environment..."
-  - ps: Start-FileDownload ('http://freefr.dl.sourceforge.net/project/nsis/NSIS%203/3.03/nsis-3.03-strlen_8192.zip') ../nsis_patch.zip
-  - ps: if ((Get-FileHash '../nsis_patch.zip').Hash -ne '023d637df9cd146f2d207fbbc627a5f63e5f71fea012523797c5af6bf342704b') { exit(1) }
-  - "7z x ../nsis_patch.zip -o%NSIS_DIR% -aoa"
-  - ps: Start-FileDownload ('http://nsis.sourceforge.net/mediawiki/images/e/eb/Textreplace.zip') ../Textreplace.zip
-  - ps: if ((Get-FileHash '../Textreplace.zip').Hash -ne '6462C0C22E87E7C81DD9076D40ACC74C515243A56F10F4F8FE720F7099DB3BA2') { exit(1) }
-  - "7z x ../Textreplace.zip -o%NSIS_DIR% -aoa"
   - ps: Start-FileDownload ('http://nsis.sourceforge.net/mediawiki/images/8/8f/UAC.zip') ../UAC.zip
   - ps: if ((Get-FileHash '../UAC.zip').Hash -ne '20E3192AF5598568887C16D88DE59A52C2CE4A26E42C5FB8BEE8105DCBBD1760') { exit(1) }
   - "7z x ../UAC.zip -o%NSIS_DIR% -aoa"
 
   # Install current hyperspy in WinPython
-  - "%CMD_IN_ENV% %WP_INSTDIR%/scripts/env.bat"
+  - "%WP_INSTDIR%/scripts/env.bat"
   # Give info about python vesion and compiler used to compile the python
-  - "%CMD_IN_ENV% python.exe -c \"import sys; print(sys.version)\""
+  - "python.exe -c \"import sys; print(sys.version)\""
 
   # Remove when updating winpython to >=2018-04
-  - "%CMD_IN_ENV% pip uninstall -y typing"
-  - "%CMD_IN_ENV% pip install --upgrade ipython ptpython jupyter-console"
+  - "pip uninstall -y typing"
+  - "pip install --upgrade ipython ptpython jupyter-console"
   # tqdm RuntimeError when running samfire tests, see https://github.com/hyperspy/hyperspy/issues/2077
-  - "%CMD_IN_ENV% pip install tqdm==4.24"
+  - "pip install tqdm==4.24"
   # Use a specific branch of hyperspy on github
   #- "%CMD_IN_ENV% pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
   # Use a release version of hyperspy
-  - "%CMD_IN_ENV% pip install hyperspy[all]"
-  - "%CMD_IN_ENV% pip install start_jupyter_cm"
-  # Try to run twice as workaround for permission error (for now, we keep master to test the bundle)
-  - "%CMD_IN_ENV% pip install https://github.com/hyperspy/hyperspyUI/archive/master.zip || pip install https://github.com/hyperspy/hyperspyUI/archive/master.zip"
+  - "pip install hyperspy[all]"
+  - "pip install hyperspyui start_jupyter_cm"
+  - "pip install atomap pixstem"
+  - "pip install https://github.com/diffpy/diffpy.structure/archive/v3.0a2.zip"
+  - "pip install https://github.com/pyxem/pyxem/archive/master.zip"
 
   # Custom installer step
   - ps: Add-AppveyorMessage "Creating installer..."
@@ -85,7 +79,7 @@ before_deploy:
   - ps: Add-AppveyorMessage "Installer created! Run tests in Winpython environment..."
   # Re-run tests in WinPython environment
   # Use matplotlib 2.2.3 until tests are not compatible with 3.0
-  - "%CMD_IN_ENV% pip install matplotlib==2.2.3 pytest-mpl"
+  - "pip install matplotlib==2.2.3 pytest-mpl"
   - ps: if($Env:PYTHON_ARCH -eq "64") {$Env:PYTHON_DIR_NAME="python-"+$Env:PYTHON_VERSION+".amd64"} else {$Env:PYTHON_DIR_NAME="python-"+$Env:PYTHON_VERSION}
   # Use hyperspy-bundle tag as version name
   - "SET BUNDLE_INST_NAME=HyperSpy-Bundle-%APPVEYOR_REPO_TAG_NAME%-py%PYTHON_VERSION_SHORT%-%PYTHON_ARCH%bit.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,9 +64,7 @@ before_deploy:
   #- "pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
   # Use a release version of hyperspy
   - "pip install hyperspy[all]"
-  - "pip install hyperspyui atomap pixstem diffpy.structure"
-  - "pip install https://github.com/ericpre/start_jupyter_cm/archive/master.zip"
-  - "pip install https://github.com/pyxem/pyxem/archive/master.zip"
+  - "pip install start_jupyter_cm hyperspyui atomap pixstem pyxem"
 
   # Clean python cache (*.pyc files and __pycache__ folders) shipped with winpython
   - "pip install pycleanup"
@@ -90,8 +88,7 @@ before_deploy:
 
   - ps: Add-AppveyorMessage "Installer created! Run tests in Winpython environment..."
   # Re-run tests in WinPython environment
-  # For hyperspy>1.4.1 remove matplotlib=2.2.3 and pytest=4.0.2
-  - "pip install matplotlib==2.2.3 pytest==4.0.2 pytest-mpl pytest-qt"
+  - "pip install pytest pytest-mpl pytest-qt"
   - "pytest --mpl --pyargs hyperspy"
   - "pytest --pyargs hyperspyui"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,16 +58,19 @@ before_deploy:
   - "python.exe -c \"import sys; print(sys.version)\""
 
   # Remove some large package to get below the NSIS 2Gb limit
-  - "pip uninstall -y pygame plotnine holoviews pulp nltk datashader"
+  - "pip uninstall -y tensorflow tensorflow_estimator tensorflow_probability torch torchvision"
 
   # Use a specific branch of hyperspy on github
   #- "pip install https://github.com/francisco-dlp/hyperspy/archive/v1.4.1.zip#egg=hyperspy[all]"
   # Use a release version of hyperspy
   - "pip install hyperspy[all]"
-  - "pip install hyperspyui"
+  - "pip install hyperspyui atomap pixstem diffpy.structure"
   - "pip install https://github.com/ericpre/start_jupyter_cm/archive/master.zip"
-  - "pip install atomap pixstem diffpy.structure"
   - "pip install https://github.com/pyxem/pyxem/archive/master.zip"
+
+  # Clean python cache (*.pyc files and __pycache__ folders) shipped with winpython
+  - "pip install pycleanup"
+  - "pushd %WP_INSTDIR% & pycleanup --cache & popd"
 
   # Custom installer step
   - ps: Add-AppveyorMessage "Creating installer..."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
 
   global:
     NSIS_DIR: "%PROGRAMFILES(x86)%/NSIS"
+    MPLBACKEND: "agg"
 
   matrix:
 
@@ -89,8 +90,13 @@ before_deploy:
   - ps: Add-AppveyorMessage "Installer created! Run tests in Winpython environment..."
   # Re-run tests in WinPython environment
   - "pip install pytest pytest-mpl pytest-qt"
-  - "pytest --mpl --pyargs hyperspy"
-  - "pytest --pyargs hyperspyui"
+  # image comparison fails with matplotlib 3.0.3
+  # - "pytest --mpl --pyargs hyperspy"
+  - "pytest --pyargs hyperspy"
+  # FIXME the test suite hold the build
+  # - "pytest --pyargs hyperspyui"
+  - "pytest --pyargs atomap"
+  - "pytest --pyargs pyxem"
 
 deploy:
   provider: GitHub

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,6 +71,7 @@ before_deploy:
 
   # Custom installer step
   - ps: Add-AppveyorMessage "Creating installer..."
+  - ps: 'Get-ChildItem -Recurse $Env:WP_INSTDIR | Measure-Object -Property Length -Sum'
   - "%PYTHON%/python.exe -m hspy_bundle.configure_installer %USERPROFILE%/wpdir %PYTHON_ARCH% %APPVEYOR_REPO_TAG_NAME%"
   - "\"%NSIS_DIR%/makensis.exe\" /V3 NSIS_installer_script-%PYTHON_ARCH%bit.nsi"
   - "ls"

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -368,13 +368,13 @@ Section "Uninstall"
 	; Currently do not create uninstaller for mode 1, so ignore
 	SetOutPath "$TEMP"
 	; Remove jupyter shortcut in context menu
-	Exec 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" remove"'
-	Sleep 3000 ; It needs a bit of time to run before it get deleted...
+	ExecWait 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" remove"' $0
+	DetailPrint "$0"
+	; Sleep 1000 ; It needs a bit of time to run before it get deleted...
 	; Clean cache so there is no left over files after uninstallation
-	Exec 'cmd.exe /C "cd "${APP_INSTDIR}\${PYTHON_FOLDER}" & Scripts\pycleanup --cache"'
+	ExecWait 'cmd.exe /C "cd "${APP_INSTDIR}\${PYTHON_FOLDER}" & Scripts\pycleanup --cache"' $0
+	DetailPrint "$0"
 	!insertmacro __DELETE_MACRO_NAME__ $INSTDIR
-	; Remove leftover python distribution directory
-	RMDir /r /REBOOTOK "${APP_INSTDIR}\${PYTHON_FOLDER}\DLL"
 	DetailPrint "Installation directory: ${APP_INSTDIR}"
 	DetailPrint "Python folder: ${PYTHON_FOLDER}"
 	DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -330,7 +330,7 @@ SectionIn RO
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\Jupyter QtConsole.lnk" "${APP_INSTDIR}\hspy_scripts\jupyter_qtconsole.bat" "$\"%HOMEPATH%$\"" "${APP_INSTDIR}\${PYTHON_FOLDER}\Lib\site-packages\start_jupyter_cm\icons\jupyter-qtconsole.ico" 0
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\WinPython prompt.lnk" "${APP_INSTDIR}\hspy_scripts\cmd.bat" "" "${APP_INSTDIR}\hspy_scripts\cmd.ico" 0
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\Python prompt.lnk" "${APP_INSTDIR}\hspy_scripts\python.bat" "" "${APP_INSTDIR}\hspy_scripts\python.ico" 0
-		CreateShortCut "$SMPROGRAMS\${APPNAME}\Spyder IDE.lnk" "${APP_INSTDIR}\hspy_scripts\spyder.bat" "" "${APP_INSTDIR}\${PYTHON_FOLDER}\Scripts\spyder.ico" 0
+		CreateShortCut "$SMPROGRAMS\${APPNAME}\Spyder IDE.lnk" "${APP_INSTDIR}\hspy_scripts\spyder.bat" "" "${APP_INSTDIR}\${PYTHON_FOLDER}\share\icons\spyder3.png" 0
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\WinPython Control Panel.lnk" "${APP_INSTDIR}\WinPython Control Panel.exe" ""
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\Uninstall ${APPNAME}.lnk" "${UNINSTALLER_FULLPATH}" "/MODE=$InstMode"
 

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -360,7 +360,7 @@ Function UN.onInit
 	${EndIf}
 
 	#Verify the uninstaller - last chance to back out
-	MessageBox MB_OKCANCEL "Permanantly remove ${APPNAME} ${APPVERSION}?" IDOK next
+	MessageBox MB_OKCANCEL "Permanantly remove ${APPNAME} ${APPVERSION}?" /SD IDOK next
 		Abort
 	next:
 FunctionEnd

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -178,17 +178,17 @@ Function InstModeSelectionPage_Create
 	${NSD_CreateLabel} 0 20u 75% 20u "Please select install type..."
 	Pop $0
 	System::Call "advapi32::GetUserName(t.r0,*i${NSIS_MAX_STRLEN})i"
-	${NSD_CreateRadioButton} 0 40u 75% 15u "Single User ($0) (no right-click shortcut)"
+	${NSD_CreateRadioButton} 0 40u 75% 15u "Single User ($0)"
 	Pop $R0
 	nsDialogs::OnClick $R0 $8
 	nsDialogs::SetUserData $R0 0
 
-	${NSD_CreateRadioButton} 0 60u 75% 15u "Portable (no right-click shortcut and startup menu entry)"
+	${NSD_CreateRadioButton} 0 60u 75% 15u "Portable (No startup menu entry)"
 	Pop $R1
 	nsDialogs::OnClick $R1 $8
 	nsDialogs::SetUserData $R1 0
 
-	${NSD_CreateRadioButton} 0 80u 75% 15u "All users (Right-click shortcut too)"
+	${NSD_CreateRadioButton} 0 80u 75% 15u "All users"
 	Pop $R2
 	nsDialogs::OnClick $R2 $8
 	nsDialogs::SetUserData $R2 1
@@ -312,7 +312,6 @@ FunctionEnd
 ; -------- Sections -----------------------------------------------------------
 Section "Required Files"
 SectionIn RO
-	; Include default MPL RC file
 	SetOutPath "${APP_INSTDIR}"
 	File /r "${WINPYTHON_PATH}\*"
 	Exec 'cmd.exe /C "${APP_INSTDIR}\hspy_scripts\compile_all.bat"'

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -360,7 +360,8 @@ Function UN.onInit
 	${EndIf}
 
 	#Verify the uninstaller - last chance to back out
-	MessageBox MB_OKCANCEL "Permanantly remove ${APPNAME} ${APPVERSION}?" /SD IDOK IDOK next
+	MessageBox MB_OKCANCEL "Permanantly remove ${APPNAME} ${APPVERSION}?" /SD IDOK IDOK next IDCANCEL cancel
+	cancel:
 		Abort
 	next:
 FunctionEnd
@@ -374,7 +375,7 @@ Section "Uninstall"
 	${EndIf}
 	!insertmacro __DELETE_MACRO_NAME__ $INSTDIR
 	# Remove leftover python distribution directory
-	RMDir "${APP_INSTDIR}\${PYTHON_FOLDER}"
+	# RMDir "${APP_INSTDIR}\${PYTHON_FOLDER}"
 	DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
 	# Remove StartMenu entries
 	Delete "$SMPROGRAMS\${APPNAME}\HyperSpyUI.lnk"

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -376,6 +376,8 @@ Section "Uninstall"
 	!insertmacro __DELETE_MACRO_NAME__ $INSTDIR
 	# Remove leftover python distribution directory
 	# RMDir "${APP_INSTDIR}\${PYTHON_FOLDER}"
+	DetailPrint "Installation directory: ${APP_INSTDIR}"
+	DetailPrint "Python folder: ${PYTHON_FOLDER}"
 	DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
 	# Remove StartMenu entries
 	Delete "$SMPROGRAMS\${APPNAME}\HyperSpyUI.lnk"

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -374,7 +374,7 @@ Section "Uninstall"
 	Exec 'cmd.exe /C "cd "${APP_INSTDIR}\${PYTHON_FOLDER}" & Scripts\pycleanup --cache"'
 	!insertmacro __DELETE_MACRO_NAME__ $INSTDIR
 	; Remove leftover python distribution directory
-	RMDir /r ""${APP_INSTDIR}"\"${PYTHON_FOLDER}"\DLL"
+	RMDir /r /REBOOTOK "${APP_INSTDIR}\${PYTHON_FOLDER}\DLL"
 	DetailPrint "Installation directory: ${APP_INSTDIR}"
 	DetailPrint "Python folder: ${PYTHON_FOLDER}"
 	DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -360,7 +360,7 @@ Function UN.onInit
 	${EndIf}
 
 	#Verify the uninstaller - last chance to back out
-	MessageBox MB_OKCANCEL "Permanantly remove ${APPNAME} ${APPVERSION}?" /SD IDOK next
+	MessageBox MB_OKCANCEL "Permanantly remove ${APPNAME} ${APPVERSION}?" /SD IDOK IDOK next
 		Abort
 	next:
 FunctionEnd

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -183,7 +183,7 @@ Function InstModeSelectionPage_Create
 	nsDialogs::OnClick $R0 $8
 	nsDialogs::SetUserData $R0 0
 
-	${NSD_CreateRadioButton} 0 60u 75% 15u "Portable (No startup menu entry)"
+	${NSD_CreateRadioButton} 0 60u 75% 15u "Portable (No startup menu entry and no right-click shortcut)"
 	Pop $R1
 	nsDialogs::OnClick $R1 $8
 	nsDialogs::SetUserData $R1 0
@@ -315,11 +315,12 @@ SectionIn RO
 	SetOutPath "${APP_INSTDIR}"
 	File /r "${WINPYTHON_PATH}\*"
 	Exec 'cmd.exe /C "${APP_INSTDIR}\hspy_scripts\compile_all.bat"'
-	; Add jupyter shortcut in context menu
-	Exec 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" add"'
 
 	${If} $InstMode <> 1
 	; Create StartMenu shortcuts
+		; Add jupyter shortcuts in context menu
+		Exec 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" add"'
+		; Add shortcuts in the start menu
 		CreateDirectory "$SMPROGRAMS\${APPNAME}"
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\HyperSpyUI.lnk" "${APP_INSTDIR}\hspy_scripts\hyperspyui.bat" "" "${APP_INSTDIR}\${PYTHON_FOLDER}\Lib\site-packages\hyperspyui\images\icon\hyperspy.ico" 0
 		CreateShortCut "$SMPROGRAMS\${APPNAME}\Jupyter Notebook.lnk" "${APP_INSTDIR}\hspy_scripts\jupyter_notebook.bat" "--notebook-dir=$\"%HOMEPATH%$\"" "${APP_INSTDIR}\${PYTHON_FOLDER}\Lib\site-packages\start_jupyter_cm\icons\jupyter.ico" 0
@@ -373,7 +374,7 @@ Section "Uninstall"
 	Exec 'cmd.exe /C "cd "${APP_INSTDIR}\${PYTHON_FOLDER}" & Scripts\pycleanup --cache"'
 	!insertmacro __DELETE_MACRO_NAME__ $INSTDIR
 	; Remove leftover python distribution directory
-	; RMDir "${APP_INSTDIR}\${PYTHON_FOLDER}"
+	RMDir /r ""${APP_INSTDIR}"\"${PYTHON_FOLDER}"\DLL"
 	DetailPrint "Installation directory: ${APP_INSTDIR}"
 	DetailPrint "Python folder: ${PYTHON_FOLDER}"
 	DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -316,10 +316,8 @@ SectionIn RO
 	SetOutPath "${APP_INSTDIR}"
 	File /r "${WINPYTHON_PATH}\*"
 	Exec 'cmd.exe /C "${APP_INSTDIR}\hspy_scripts\compile_all.bat"'
-	${If} $InstMode = 2
-	; Create right-click context menu entries for Hyperspy Here
-		Exec 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" add"'
-	${EndIf}
+	; Add jupyter shortcut in context menu
+	Exec 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" add"'
 
 	${If} $InstMode <> 1
 	; Create StartMenu shortcuts
@@ -369,10 +367,9 @@ FunctionEnd
 Section "Uninstall"
 	; Currently do not create uninstaller for mode 1, so ignore
 	SetOutPath "$TEMP"
-	${If} $InstMode = 2
-		Exec 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" remove"'
-		Sleep 3000 ; It needs a bit of time to run before it get deleted...
-	${EndIf}
+	; Remove jupyter shortcut in context menu
+	Exec 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" remove"'
+	Sleep 3000 ; It needs a bit of time to run before it get deleted...
 	!insertmacro __DELETE_MACRO_NAME__ $INSTDIR
 	# Remove leftover python distribution directory
 	# RMDir "${APP_INSTDIR}\${PYTHON_FOLDER}"

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -373,6 +373,8 @@ Section "Uninstall"
 		Sleep 3000 ; It needs a bit of time to run before it get deleted...
 	${EndIf}
 	!insertmacro __DELETE_MACRO_NAME__ $INSTDIR
+	# Remove leftover python distribution directory
+	RMDir "${APP_INSTDIR}\${PYTHON_FOLDER}"
 	DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
 	# Remove StartMenu entries
 	Delete "$SMPROGRAMS\${APPNAME}\HyperSpyUI.lnk"

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -370,7 +370,7 @@ Section "Uninstall"
 	Exec 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" remove"'
 	Sleep 3000 ; It needs a bit of time to run before it get deleted...
 	; Clean cache so there is no left over files after uninstallation
-	Exec 'cmd.exe /C "cd ${APP_INSTDIR}\${PYTHON_FOLDER}" & Scripts\pycleanup" --cache"'
+	Exec 'cmd.exe /C "cd "${APP_INSTDIR}\${PYTHON_FOLDER}" & Scripts\pycleanup --cache"'
 	!insertmacro __DELETE_MACRO_NAME__ $INSTDIR
 	; Remove leftover python distribution directory
 	; RMDir "${APP_INSTDIR}\${PYTHON_FOLDER}"

--- a/hspy_bundle/NSIS_installer_script.nsi
+++ b/hspy_bundle/NSIS_installer_script.nsi
@@ -370,13 +370,15 @@ Section "Uninstall"
 	; Remove jupyter shortcut in context menu
 	Exec 'cmd.exe /C ""${APP_INSTDIR}\hspy_scripts\jupyter_cm.bat" remove"'
 	Sleep 3000 ; It needs a bit of time to run before it get deleted...
+	; Clean cache so there is no left over files after uninstallation
+	Exec 'cmd.exe /C "cd ${APP_INSTDIR}\${PYTHON_FOLDER}" & Scripts\pycleanup" --cache"'
 	!insertmacro __DELETE_MACRO_NAME__ $INSTDIR
-	# Remove leftover python distribution directory
-	# RMDir "${APP_INSTDIR}\${PYTHON_FOLDER}"
+	; Remove leftover python distribution directory
+	; RMDir "${APP_INSTDIR}\${PYTHON_FOLDER}"
 	DetailPrint "Installation directory: ${APP_INSTDIR}"
 	DetailPrint "Python folder: ${PYTHON_FOLDER}"
 	DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
-	# Remove StartMenu entries
+	; Remove StartMenu entries
 	Delete "$SMPROGRAMS\${APPNAME}\HyperSpyUI.lnk"
 	Delete "$SMPROGRAMS\${APPNAME}\Jupyter Notebook.lnk"
 	Delete "$SMPROGRAMS\${APPNAME}\Jupyter QtConsole.lnk"


### PR DESCRIPTION
* Add jupyter shortcut in context menu for single users for installation without admin right,
* update to last winpython distribution,
* clean cache (*pyc) before uninstallation, so there is no left over files.
* remove tensorflow and torch to get below the 2Go limit of NSIS.
* include atomap, pixstem and pyxem
* run test suite for atomap and pyxem

This is pending a HyperSpyUI release because of the pyqt 5.12 icon issue.