### PR TITLE
Update to winpython 2019-02

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
        PYTHON_ARCH: "64"
        WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython64-3.7.4.0rc.exe'
        WP_CRC: '5701b68128a69926f8b7a136fc3e3b1e0b64b07e6ccb21d1995db3d879617a49'
-       WP_DIR_NAME: WPy64-3740"
+       WP_DIR_NAME: 'WPy64-3740'
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -38,13 +38,14 @@ build: false  # Not a C# project, build stuff at the test step instead.
 before_deploy:
   # Download WinPython installer if not cached
   - ps: Add-AppveyorMessage "Installing WinPython..."
-  - "SET WP_DIR=%USERPROFILE%\\%WP_DIR_NAME%"
-  - "SET WP_EXE=%USERPROFILE%\\WinPython3.exe"
+  - "SET WP_DIR=%USERPROFILE%/%WP_DIR_NAME%"
+  - "SET WP_EXE=%USERPROFILE%/WinPython3.exe"
   - ps: appveyor DownloadFile $Env:WP_URL -FileName $Env:WP_EXE
   - ps: Write-Output (Get-FileHash $Env:WP_EXE)
   - ps: if ((Get-FileHash $Env:WP_EXE).Hash -ne $Env:WP_CRC) { exit(1) }
   - ps: (& $Env:WP_EXE -y | Out-Null )
   - "ls"
+  - "ls %USERPROFILE%"
   - "ls %WP_DIR%"
 
   # Install UAC plugin
@@ -69,12 +70,12 @@ before_deploy:
 
   # Clean python cache (*.pyc files and __pycache__ folders) shipped with winpython
   - "pip install pycleanup"
-  - "pushd %WP_DIR% & pycleanup --cache & popd"
+  - "pushd %USERPROFILE% & pycleanup --cache & popd"
 
   # Custom installer step
   - ps: Add-AppveyorMessage "Creating installer..."
   - ps: 'Get-ChildItem -Recurse $Env:WP_DIR | Measure-Object -Property Length -Sum'
-  - "%PYTHON%/python.exe -m hspy_bundle.configure_installer %USERPROFILE%/wpdir %PYTHON_ARCH% %APPVEYOR_REPO_TAG_NAME%"
+  - "%PYTHON%/python.exe -m hspy_bundle.configure_installer %USERPROFILE% %PYTHON_ARCH% %APPVEYOR_REPO_TAG_NAME%"
   - "\"%NSIS_DIR%/makensis.exe\" /V3 NSIS_installer_script-%PYTHON_ARCH%bit.nsi"
   - "ls"
   # Use hyperspy-bundle tag as version name

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,13 @@ environment:
 
   matrix:
 
-     #- PYTHON: "C:\\Miniconda37"
-     #  PYTHON_VERSION_SHORT: "37"
-     #  PYTHON_VERSION: "3.7.4"
-     #  PYTHON_ARCH: "32"
-     #  WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython32-3.7.4.0rc.exe'
-     #  WP_CRC: '0a53bba8d413278317fa5d5a886973123cad9b2ba837a979b4337464c74fad6a'
+     - PYTHON: "C:\\Miniconda37"
+       PYTHON_VERSION_SHORT: "37"
+       PYTHON_VERSION: "3.7.4"
+       PYTHON_ARCH: "32"
+       WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython32-3.7.4.0rc.exe'
+       WP_CRC: '0a53bba8d413278317fa5d5a886973123cad9b2ba837a979b4337464c74fad6a'
+       WP_DIR_NAME: 'WPy32-3740'
 
      - PYTHON: "C:\\Miniconda37-x64"
        PYTHON_VERSION_SHORT: "37"
@@ -70,7 +71,7 @@ before_deploy:
 
   # Clean python cache (*.pyc files and __pycache__ folders) shipped with winpython
   - "pip install pycleanup"
-  - "pushd %USERPROFILE% & pycleanup --cache & popd"
+  - "pushd %WP_INSTDIR% & pycleanup --cache & popd"
 
   # Custom installer step
   - ps: Add-AppveyorMessage "Creating installer..."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,22 +8,21 @@ environment:
     MPLBACKEND: "agg"
 
   matrix:
+     - PYTHON: "C:\\Miniconda37-x64"
+       PYTHON_VERSION_SHORT: "37"
+       PYTHON_VERSION: "3.7.4"
+       PYTHON_ARCH: "64"
+       WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/Winpython64-3.7.4.0.exe'
+       WP_CRC: '5701b68128a69926f8b7a136fc3e3b1e0b64b07e6ccb21d1995db3d879617a49'
+       WP_DIR_NAME: 'WPy64-3740'
 
      - PYTHON: "C:\\Miniconda37"
        PYTHON_VERSION_SHORT: "37"
        PYTHON_VERSION: "3.7.4"
        PYTHON_ARCH: "32"
-       WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython32-3.7.4.0rc.exe'
+       WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/Winpython32-3.7.4.0.exe'
        WP_CRC: '0a53bba8d413278317fa5d5a886973123cad9b2ba837a979b4337464c74fad6a'
        WP_DIR_NAME: 'WPy32-3740'
-
-     - PYTHON: "C:\\Miniconda37-x64"
-       PYTHON_VERSION_SHORT: "37"
-       PYTHON_VERSION: "3.7.4"
-       PYTHON_ARCH: "64"
-       WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython64-3.7.4.0rc.exe'
-       WP_CRC: '5701b68128a69926f8b7a136fc3e3b1e0b64b07e6ccb21d1995db3d879617a49'
-       WP_DIR_NAME: 'WPy64-3740'
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -71,7 +70,7 @@ before_deploy:
 
   # Clean python cache (*.pyc files and __pycache__ folders) shipped with winpython
   - "pip install pycleanup"
-  - "pushd %WP_INSTDIR% & pycleanup --cache & popd"
+  - "pushd %WP_DIR% & pycleanup --cache & popd"
 
   # Custom installer step
   - ps: Add-AppveyorMessage "Creating installer..."

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,14 +11,14 @@ environment:
 
      - PYTHON: "C:\\Miniconda37"
        PYTHON_VERSION_SHORT: "37"
-       PYTHON_VERSION: "3.7.2"
+       PYTHON_VERSION: "3.7.4"
        PYTHON_ARCH: "32"
        WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython32-3.7.4.0rc.exe'
        WP_CRC: '0a53bba8d413278317fa5d5a886973123cad9b2ba837a979b4337464c74fad6a'
 
      - PYTHON: "C:\\Miniconda37-x64"
        PYTHON_VERSION_SHORT: "37"
-       PYTHON_VERSION: "3.7.2"
+       PYTHON_VERSION: "3.7.4"
        PYTHON_ARCH: "64"
        WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython64-3.7.4.0rc.exe'
        WP_CRC: '5701b68128a69926f8b7a136fc3e3b1e0b64b07e6ccb21d1995db3d879617a49'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,15 +13,15 @@ environment:
        PYTHON_VERSION_SHORT: "37"
        PYTHON_VERSION: "3.7.2"
        PYTHON_ARCH: "32"
-       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.11.20190223/Winpython32-3.7.2.0.exe'
-       WP_CRC: '40a80d2fba1348da785bd97ee8de4e69c554c3d9dcd632b623a0f12e3ddb5ec0'
+       WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython32-3.7.4.0rc.exe'
+       WP_CRC: '0a53bba8d413278317fa5d5a886973123cad9b2ba837a979b4337464c74fad6a'
 
      - PYTHON: "C:\\Miniconda37-x64"
        PYTHON_VERSION_SHORT: "37"
        PYTHON_VERSION: "3.7.2"
        PYTHON_ARCH: "64"
-       WP_URL: 'https://github.com/winpython/winpython/releases/download/1.11.20190223/Winpython64-3.7.2.0.exe'
-       WP_CRC: '3fb3ece2ba20fa903f15b642f5749a4517c2557788801197a981eea11ec21865'
+       WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython64-3.7.4.0rc.exe'
+       WP_CRC: '5701b68128a69926f8b7a136fc3e3b1e0b64b07e6ccb21d1995db3d879617a49'
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -90,9 +90,7 @@ before_deploy:
   - ps: Add-AppveyorMessage "Installer created! Run tests in Winpython environment..."
   # Re-run tests in WinPython environment
   - "pip install pytest pytest-mpl pytest-qt"
-  # image comparison fails with matplotlib 3.0.3
-  # - "pytest --mpl --pyargs hyperspy"
-  - "pytest --pyargs hyperspy"
+  - "pytest --mpl --pyargs hyperspy"
   # FIXME the test suite hold the build
   # - "pytest --pyargs hyperspyui"
   - "pytest --pyargs atomap"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,12 +9,12 @@ environment:
 
   matrix:
 
-     - PYTHON: "C:\\Miniconda37"
-       PYTHON_VERSION_SHORT: "37"
-       PYTHON_VERSION: "3.7.4"
-       PYTHON_ARCH: "32"
-       WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython32-3.7.4.0rc.exe'
-       WP_CRC: '0a53bba8d413278317fa5d5a886973123cad9b2ba837a979b4337464c74fad6a'
+     #- PYTHON: "C:\\Miniconda37"
+     #  PYTHON_VERSION_SHORT: "37"
+     #  PYTHON_VERSION: "3.7.4"
+     #  PYTHON_ARCH: "32"
+     #  WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython32-3.7.4.0rc.exe'
+     #  WP_CRC: '0a53bba8d413278317fa5d5a886973123cad9b2ba837a979b4337464c74fad6a'
 
      - PYTHON: "C:\\Miniconda37-x64"
        PYTHON_VERSION_SHORT: "37"
@@ -22,6 +22,7 @@ environment:
        PYTHON_ARCH: "64"
        WP_URL: 'https://downloads.sourceforge.net/project/winpython/WinPython_3.7/3.7.4.0/betas/Winpython64-3.7.4.0rc.exe'
        WP_CRC: '5701b68128a69926f8b7a136fc3e3b1e0b64b07e6ccb21d1995db3d879617a49'
+       WP_DIR_NAME: WPy64-3740"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
@@ -37,15 +38,14 @@ build: false  # Not a C# project, build stuff at the test step instead.
 before_deploy:
   # Download WinPython installer if not cached
   - ps: Add-AppveyorMessage "Installing WinPython..."
-  - "SET WP_INSTDIR=%USERPROFILE%\\wpdir\\WinPython-%PYTHON_ARCH%\\"
-  - "SET WP_EXE=%USERPROFILE%/wpdir/WinPython3-%PYTHON_ARCH%bit.exe"
-  - "mkdir %USERPROFILE%\\wpdir"
+  - "SET WP_DIR=%USERPROFILE%\\%WP_DIR_NAME%"
+  - "SET WP_EXE=%USERPROFILE%\\WinPython3.exe"
   - ps: appveyor DownloadFile $Env:WP_URL -FileName $Env:WP_EXE
   - ps: Write-Output (Get-FileHash $Env:WP_EXE)
   - ps: if ((Get-FileHash $Env:WP_EXE).Hash -ne $Env:WP_CRC) { exit(1) }
-  - ps: (& $Env:WP_EXE /VERYSILENT /DIR=$Env:WP_INSTDIR | Out-Null )
-  - "ls %USERPROFILE%/wpdir"
-  - "ls %WP_INSTDIR%"
+  - ps: (& $Env:WP_EXE -y | Out-Null )
+  - "ls"
+  - "ls %WP_DIR%"
 
   # Install UAC plugin
   - ps: Add-AppveyorMessage "Setting up WinPython environment..."
@@ -54,7 +54,7 @@ before_deploy:
   - "7z x ../UAC.zip -o%NSIS_DIR% -aoa"
 
   # Install current hyperspy in WinPython
-  - "%WP_INSTDIR%/scripts/env.bat"
+  - "%WP_DIR%/scripts/env.bat"
   # Give info about python vesion and compiler used to compile the python
   - "python.exe -c \"import sys; print(sys.version)\""
 
@@ -69,11 +69,11 @@ before_deploy:
 
   # Clean python cache (*.pyc files and __pycache__ folders) shipped with winpython
   - "pip install pycleanup"
-  - "pushd %WP_INSTDIR% & pycleanup --cache & popd"
+  - "pushd %WP_DIR% & pycleanup --cache & popd"
 
   # Custom installer step
   - ps: Add-AppveyorMessage "Creating installer..."
-  - ps: 'Get-ChildItem -Recurse $Env:WP_INSTDIR | Measure-Object -Property Length -Sum'
+  - ps: 'Get-ChildItem -Recurse $Env:WP_DIR | Measure-Object -Property Length -Sum'
   - "%PYTHON%/python.exe -m hspy_bundle.configure_installer %USERPROFILE%/wpdir %PYTHON_ARCH% %APPVEYOR_REPO_TAG_NAME%"
   - "\"%NSIS_DIR%/makensis.exe\" /V3 NSIS_installer_script-%PYTHON_ARCH%bit.nsi"
   - "ls"

--- a/hspy_bundle/configure_installer.py
+++ b/hspy_bundle/configure_installer.py
@@ -165,7 +165,7 @@ class HSpyBundleInstaller:
         │   ├── package1
         │   ├── package2
         │   └── ...
-        └── WinPython-ARCH*
+        └── WP-ARCH*
             ├── f1
             ├── f2
             └── ...
@@ -182,7 +182,7 @@ class HSpyBundleInstaller:
         self.arch = arch
         try:
             self.wppath = dict((
-                (a, glob(os.path.join(dist_path, "WinPython-%s*" % a))[0])
+                (a, glob(os.path.join(dist_path, "WPy%s-*" % a))[0])
                 for a in arch))
         except IndexError:
             raise RuntimeError("No Winpython distribution can be found.")
@@ -326,8 +326,8 @@ if __name__ == "__main__":
     if len(sys.argv) > 2:
         arch = sys.argv[2].split(',')
     else:
-        dirs = glob(os.path.join(bundle_dir, "WinPython-*"))
-        dirs = [d.lstrip(os.path.join(bundle_dir, "WinPython-")) for d in dirs]
+        dirs = glob(os.path.join(bundle_dir, "WPy*"))
+        dirs = [d.lstrip(os.path.join(bundle_dir, "WPy")) for d in dirs]
         arch = tuple(set([d[0:2] for d in dirs]))
     if len(sys.argv) > 3:
         version = sys.argv[3]

--- a/hspy_bundle/configure_installer.py
+++ b/hspy_bundle/configure_installer.py
@@ -165,7 +165,7 @@ class HSpyBundleInstaller:
         │   ├── package1
         │   ├── package2
         │   └── ...
-        └── WP-ARCH*
+        └── WPyARCH-*
             ├── f1
             ├── f2
             └── ...


### PR DESCRIPTION
- [x] Update to winpython 2019-02rc,
- [x] adapt for winpython installer change (from inno setup to 7zip self-executing installer) and winpython folder name,
- [x] ready for review.

One particularly interesting change in WinPython 2019-02 is that it comes with jupyterlab 1.0.2 which has a significantly improved contextual help!

I have asked when 2019-02 is going to be released (https://github.com/winpython/winpython/issues/724) in order to know if we should wait a couple of days or go with 2019-02rc, which would possibly identical to 2019-02 for python 3.7. In any case, I have tested the 64 bits bundle and it works well.