### PR TITLE
Update bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,10 +146,10 @@ jobs:
     needs: create_release_job
     runs-on: windows-latest
     env:
-      WP_URL: https://github.com/winpython/winpython/releases/download/2.3.20200530/Winpython64-3.8.3.0cod.exe
-      WP_SHA256: f3870e8570b5f3e31821756089af1237859a6db8a971c1fea14a560d4c85a314
+      WP_URL: https://github.com/winpython/winpython/releases/download/3.0.20201028/Winpython64-3.8.6.0cod.exe
+      WP_SHA256: d1457a5732825d0717f54e45e9d1f8ea890974e317d0b797a99b5d70b59d6839
       WP_EXE: winpython.exe
-      WP_DIR_NAME: WPy64-3830
+      WP_DIR_NAME: WPy64-3860
       MPLBACKEND: agg
       TEST_DEPS: pytest pytest-mpl
       LIB_TO_INSTALL: hyperspy[all] hyperspyui pyxem atomap kikuchipy
@@ -179,13 +179,13 @@ jobs:
           where pip
           pip install wheel
           pip install ${{ env.LIB_TO_INSTALL }}
-          pip install --upgrade ${{ env.LIB_TO_UPGRADE }}
+          pip install --use-feature=2020-resolver ${{ env.LIB_TO_UPGRADE }}
 
       - name: Set installer name
         env:
           version: ${{ needs.create_release_job.outputs.version }}
         run: |
-          $installer_name = "HyperSpy-bundle-${{ env.version }}-Windows-x86_64-Portable.exe"
+          $installer_name="HyperSpy-bundle-${{ env.version }}-Windows-x86_64-Portable.exe"
           echo "asset_name=$installer_name" >> $GITHUB_ENV
 
       - name: Create installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         name: Set asset name
         run: |
           fname=(HyperSpy-*.${{ matrix.config.INSTALLER_EXTENSION }})
-          echo ::set-env name=asset_name::$fname
+          echo "asset_name=$fname >> $GITHUB_ENV
           echo $fname
 
       - name: Get hash
@@ -84,13 +84,13 @@ jobs:
         env:
           install_dir: '${{ github.workspace }}/new_distribution'
         run: |
-          echo ::set-env name=install_dir::${{ env.install_dir }}
+          echo "install_dir=${{ env.install_dir }}" >> $GITHUB_ENV
           bash ${{ env.asset_name }} -b -p ${{ env.install_dir }}
 
       - name: Install new distribution (MacOS)
         if: runner.os == 'macos'
         run: |
-          echo "::set-env name=install_dir::/Users/runner"
+          echo "install_dir=/Users/runner" >> $GITHUB_ENV
           installer -pkg ${{ env.asset_name }} -target CurrentUserHomeDirectory
 
       - name: Install new distribution (Windows)
@@ -99,7 +99,7 @@ jobs:
           install_dir: '${{ github.workspace }}\nd'
         shell: powershell
         run: |
-          echo "::set-env name=install_dir::${{ env.install_dir }}"
+          echo "install_dir=${{ env.install_dir }}" >> $GITHUB_EN
           Start-Process -Wait -FilePath ${{ env.asset_name }} -ArgumentList "/S /AddToPath=0 /RegisterPython=0 /NoScripts=1 /D=${{ env.install_dir }}"
 
       - name: Upload artifact
@@ -182,7 +182,7 @@ jobs:
           tag: ${{ steps.get_tag.outputs.version-without-v }}
         run: |
           $installer_name = "HyperSpy-bundle-${{ env.tag }}-Windows-x86_64-Portable.exe"
-          echo "::set-env name=asset_name::$installer_name"
+          echo "asset_name=$installer_name" >> $GITHUB_ENV
 
       - name: Create installer
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         name: Set asset name
         run: |
           fname=(HyperSpy-*.${{ matrix.config.INSTALLER_EXTENSION }})
-          echo "asset_name=$fname >> $GITHUB_ENV
+          echo "asset_name=$fname" >> $GITHUB_ENV
           echo $fname
 
       - name: Get hash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs: 
       upload_url: ${{ steps.create_release.outputs.upload_url }}
-      version: ${{ steps.get_version.outputs.version }}
+      VERSION: ${{ env.VERSION }}
     steps:
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
@@ -28,7 +28,10 @@ jobs:
       - name: Get version
         id: get_version
         run: |
-          echo "version=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Display version
+        run: |
+          echo ${{ env.VERSION }}
 
   build:
     name: ${{ matrix.config.os }}
@@ -72,7 +75,7 @@ jobs:
       - shell: bash -l {0}
         name: Build distribution
         env:
-          version: ${{ needs.create_release_job.outputs.version }}
+          VERSION: ${{ needs.create_release_job.outputs.VERSION }}
         run: |
           constructor -v conda_distribution
 
@@ -185,9 +188,9 @@ jobs:
       - shell: bash -l {0}
         name: Set installer name
         env:
-          version: ${{ needs.create_release_job.outputs.version }}
+          VERSION: ${{ needs.create_release_job.outputs.VERSION }}
         run: |
-          installer_name=HyperSpy-bundle-${{ env.version }}-Windows-x86_64-Portable.exe
+          installer_name=HyperSpy-bundle-${{ env.VERSION }}-Windows-x86_64-Portable.exe
           echo "asset_name=$installer_name" >> $GITHUB_ENV
           echo $installer_name
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: goanpeca/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
           python-version: 3.7
@@ -61,7 +61,7 @@ jobs:
         name: Install constructor
         run: |
           conda install constructor --only-deps
-          pip install https://github.com/conda/constructor/archive/3.1.0.zip --no-deps
+          pip install https://github.com/ericpre/constructor/archive/master.zip --no-deps
 
       - shell: bash -l {0}
         name: Build distribution

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
           install_dir: '${{ github.workspace }}\nd'
         shell: powershell
         run: |
-          echo "install_dir=${{ env.install_dir }}" >> $GITHUB_EN
+          echo "install_dir=${{ env.install_dir }}" >> $GITHUB_ENV
           Start-Process -Wait -FilePath ${{ env.asset_name }} -ArgumentList "/S /AddToPath=0 /RegisterPython=0 /NoScripts=1 /D=${{ env.install_dir }}"
 
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,9 @@ jobs:
       WP_EXE: winpython.exe
       WP_DIR_NAME: WPy64-3860
       MPLBACKEND: agg
-      TEST_DEPS: pytest pytest-mpl
+      # remove `pytest-tornasync` test dependency when more recent jupyter_server is available
+      # https://github.com/jupyter-server/jupyter_server/issues/337
+      TEST_DEPS: pytest pytest-mpl pytest-tornasync
       LIB_TO_INSTALL: hyperspy[all] hyperspyui pyxem atomap kikuchipy
       LIB_TO_UPGRADE: hyperspy
       LIB_TO_TEST: hyperspy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,13 +114,18 @@ jobs:
           echo "install_dir=/Users/runner" >> $GITHUB_ENV
           installer -pkg ${{ env.asset_name }} -target CurrentUserHomeDirectory
 
-      - name: Install new distribution (Windows)
+      - name: Install new distribution 1 (Windows)
         if: runner.os == 'windows'
         env:
           install_dir: '${{ github.workspace }}\nd'
-        shell: powershell
+        shell: bash
         run: |
           echo "install_dir=${{ env.install_dir }}" >> $GITHUB_ENV
+
+      - name: Install new distribution 2 (Windows)
+        if: runner.os == 'windows'
+        shell: powershell
+        run: |
           Start-Process -Wait -FilePath ${{ env.asset_name }} -ArgumentList "/S /AddToPath=0 /RegisterPython=0 /NoScripts=1 /D=${{ env.install_dir }}"
 
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,15 +157,6 @@ jobs:
       LIB_TO_TEST: hyperspy
 
     steps:
-      - shell: bash -l {0}
-        name: Set installer name
-        env:
-          version: ${{ needs.create_release_job.outputs.version }}
-        run: |
-          installer_name=HyperSpy-bundle-${{ env.version }}-Windows-x86_64-Portable.exe
-          echo "asset_name=$installer_name" >> $GITHUB_ENV
-          echo $installer_name
-
       - name: Download Winpython
         run: |
           Invoke-WebRequest -OutFile ${{ env.WP_EXE }} ${{ env.WP_URL }}
@@ -186,7 +177,6 @@ jobs:
           call "${{ env.WP_DIR_NAME }}\scripts\env.bat"
           where python
           where pip
-          pip install wheel
           pip install --use-feature=2020-resolver ${{ env.LIB_TO_INSTALL }}
           pip install --upgrade --use-feature=2020-resolver ${{ env.LIB_TO_UPGRADE }}
 
@@ -198,6 +188,14 @@ jobs:
           installer_name=HyperSpy-bundle-${{ env.version }}-Windows-x86_64-Portable.exe
           echo "asset_name=$installer_name" >> $GITHUB_ENV
           echo $installer_name
+
+      - name: Run pyclean in distribution folder
+        shell: cmd
+        run: |
+          where pip
+          pip install pyclean
+          where pyclean
+          pyclean ${{ env.WP_DIR_NAME }}
 
       - name: Create installer
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       VERSION: ${{ env.VERSION }}
     steps:
+      - uses: actions/checkout@v2
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         id: create_release
@@ -29,10 +30,15 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Get version
-        id: get_version
+      - name: Get version (on tag)
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Get version (short hash)
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        run: |
+          # Use git short hash instead of tag
+          echo "VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Display version
         run: |
           echo ${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,9 +79,9 @@ jobs:
       - shell: bash -l {0}
         name: Set asset name
         run: |
-          fname=(HyperSpy-*.${{ matrix.config.INSTALLER_EXTENSION }})
-          echo "asset_name=$fname" >> $GITHUB_ENV
-          echo $fname
+          installer_name=(HyperSpy-*.${{ matrix.config.INSTALLER_EXTENSION }})
+          echo "asset_name=$installer_name" >> $GITHUB_ENV
+          echo $installer_name
 
       - name: Get hash
         run: |
@@ -153,10 +153,19 @@ jobs:
       MPLBACKEND: agg
       TEST_DEPS: pytest pytest-mpl
       LIB_TO_INSTALL: hyperspy[all] hyperspyui pyxem atomap kikuchipy
-      LIB_TO_UPGRADE: pint numba
+      LIB_TO_UPGRADE: hyperspy
       LIB_TO_TEST: hyperspy
 
     steps:
+      - shell: bash -l {0}
+        name: Set installer name
+        env:
+          version: ${{ needs.create_release_job.outputs.version }}
+        run: |
+          installer_name=HyperSpy-bundle-${{ env.version }}-Windows-x86_64-Portable.exe
+          echo "asset_name=$installer_name" >> $GITHUB_ENV
+          echo $installer_name
+
       - name: Download Winpython
         run: |
           Invoke-WebRequest -OutFile ${{ env.WP_EXE }} ${{ env.WP_URL }}
@@ -178,15 +187,17 @@ jobs:
           where python
           where pip
           pip install wheel
-          pip install ${{ env.LIB_TO_INSTALL }}
-          pip install --use-feature=2020-resolver ${{ env.LIB_TO_UPGRADE }}
+          pip install --use-feature=2020-resolver ${{ env.LIB_TO_INSTALL }}
+          pip install --upgrade --use-feature=2020-resolver ${{ env.LIB_TO_UPGRADE }}
 
-      - name: Set installer name
+      - shell: bash -l {0}
+        name: Set installer name
         env:
           version: ${{ needs.create_release_job.outputs.version }}
         run: |
-          $installer_name="HyperSpy-bundle-${{ env.version }}-Windows-x86_64-Portable.exe"
+          installer_name=HyperSpy-bundle-${{ env.version }}-Windows-x86_64-Portable.exe
           echo "asset_name=$installer_name" >> $GITHUB_ENV
+          echo $installer_name
 
       - name: Create installer
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,14 @@
 name: Release
 
-on: [push]
-  #push:
-  #   Sequence of patterns matched against refs/tags
-  #  tags:
-  #  - '*' # Push events to matching v*, i.e. v1.0, v20.15.10
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   create_release_job:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
         name: Install constructor
         run: |
           conda install constructor --only-deps
+          conda install jinja2
           pip install https://github.com/ericpre/constructor/archive/master.zip --no-deps
 
       - shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,7 @@ jobs:
         name: Install constructor
         run: |
           conda install constructor --only-deps
-          conda install conda-standalone
-          pip install https://github.com/ericpre/constructor/archive/master.zip --no-deps
+          pip install https://github.com/conda/constructor/archive/3.1.0.zip --no-deps
 
       - shell: bash -l {0}
         name: Build distribution

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs: 
       upload_url: ${{ steps.create_release.outputs.upload_url }}
+      version: ${{ steps.get_version.outputs.version }}
     steps:
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
@@ -24,6 +25,10 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
+      - name: Get version
+        id: get_version
+        run: |
+          echo "version=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
   build:
     name: ${{ matrix.config.os }}
@@ -66,6 +71,8 @@ jobs:
 
       - shell: bash -l {0}
         name: Build distribution
+        env:
+          version: ${{ needs.create_release_job.outputs.version }}
         run: |
           constructor -v conda_distribution
 
@@ -174,15 +181,11 @@ jobs:
           pip install ${{ env.LIB_TO_INSTALL }}
           pip install --upgrade ${{ env.LIB_TO_UPGRADE }}
 
-      - name: Get tag
-        id: get_tag
-        uses: battila7/get-version-action@v2
-
       - name: Set installer name
         env:
-          tag: ${{ steps.get_tag.outputs.version-without-v }}
+          version: ${{ needs.create_release_job.outputs.version }}
         run: |
-          $installer_name = "HyperSpy-bundle-${{ env.tag }}-Windows-x86_64-Portable.exe"
+          $installer_name = "HyperSpy-bundle-${{ env.version }}-Windows-x86_64-Portable.exe"
           echo "asset_name=$installer_name" >> $GITHUB_ENV
 
       - name: Create installer
@@ -216,7 +219,6 @@ jobs:
         run: |
           call "${{ env.WP_DIR_NAME }}\scripts\env.bat"
           pytest --pyargs ${{ env.LIB_TO_TEST }}
-
 
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -41,8 +41,14 @@ from the shortcut menu will allow to run the installer, as explained in the [mac
 
 ### Silent installation on Windows
 
+Using the command prompt
 ```
 start /wait "" HyperSpy-bundle-2020.02.05-Windows-x86_64.exe /S /D=%UserProfile%\HyperSpy-bundle
+```
+
+Using PowerShell
+```
+Start-Process -Wait -FilePath HyperSpy-bundle-2020.02.05-Windows-x86_64.exe -ArgumentList /S /D=$env:UserProfile\HyperSpy-bundle
 ```
 
 See the [Anaconda documentation](https://docs.anaconda.com/anaconda/install/silent-mode) for more information.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ See the [Anaconda documentation](https://docs.anaconda.com/anaconda/install/sile
 
 ## Portable distribution
 
-HyperSpy Bundle does not interact with any other Python installation, so it can be safely installed alongside other
-Python distributions. Since it is a portable distribution, it can be installed on external harddrive or it can be moved to any other
-folder.
+The portable version of the HyperSpy Bundle does not interact with other Python installation, and it can be safely installed alongside other Python distributions. As a portable distribution, no shortcut is installed and it can be installed on external harddrive or it can be moved to any other folder.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ from the shortcut menu will allow to run the installer, as explained in the [mac
 ### Differences with Anaconda/Miniconda
 
 * Include the packages mentioned above
-* The conda packages are download from the *anaconda main*, *conda-forge* channels in this order of priority 
+* The conda packages are download from the *conda-forge* and *anaconda main* channels in this order of priority 
   and these channels are set up in the installed environment.
-* Adds context menu entries (right-click shortcut) to start the *Jupyter Notebook*, *Jyputer Lab* or *Juypter QtConsole*.
+* Adds context menu entries (right-click shortcut) to start the *Jupyter Notebook*, *Jupyter Lab* or *Juypter QtConsole*.
   See [start_jupyter_cm](https://github.com/hyperspy/start_jupyter_cm) for details.
 * Remove context menu entries when uninstalling on Windows only. For Linux and MaxOSX, no uninstall is provided and
   the context menu entries needs to be removed manually using `start_jupyter_cm --remove` from the conda environment before

--- a/RELEASING_GUIDE.md
+++ b/RELEASING_GUIDE.md
@@ -3,16 +3,15 @@ This repository contains the scripts to make Anaconda based distribution
 
 ## Preliminaries
 
-- Update the `version` in `hyperspy-bundle/conda_distribution/construct.yaml`
 - Update the included packages (if necessary) in:
   - `hyperspy-bundle/conda_distribution/construct.yaml`
   - `hyperspy-bundle/.github/workflows/release.yml` as defined by the `LIB_TO_INSTALL`
-    and `LIB_TO_UPGRADE` variables
+    and `LIB_TO_UPGRADE` variables for the WinPython distribution.
 - Update WinPython to latest (if necessary), in `hyperspy-bundle/.github/workflows/release.yml`
   update the variable `WP_URL`, `WP_SHA256`, `WP_DIR_NAME`
 - Push a commit to check if the build is successful.
 
 ## Release
-- Push a tag (same as the version defined in `construct.yaml`)
+- Push a tag
 
 

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -1,10 +1,9 @@
 name: HyperSpy-bundle
 version: 2020.11.14
 
-install_in_dependency_order: True
 # Error: File 'lib/libiomp5.dylib' found in multiple packages: intel-openmp-2019.4-233.conda, llvm-openmp-10.0.0-h28b9765_0.conda
 # Error: File 'lib/python3.8/__pycache__/_sysconfigdata_x86_64_conda_cos6_linux_gnu.cpython-38.pyc' found in multiple packages: ujson-1.35-py38h7b6447c_0.conda, pyqt-5.9.2-py38h05f1152_4.conda, lazy-object-proxy-1.4.3-py38h7b6447c_0.conda, python-blosc-1.7.0-py38h7b6447c_0.conda, markupsafe-1.1.1-py38h7b6447c_0.conda, python-3.8.5-hcff3b4d_0.conda, pycifrw-4.4.1-py38h516909a_0.tar.bz2, wrapt-1.11.2-py38h7b6447c_0.conda, gmpy2-2.0.8-py38hd5f6e3b_3.conda, fastcache-1.1.0-py38h7b6447c_0.conda
-ignore_duplicate_files: True  # [unix]
+ignore_duplicate_files: True
 
 channels:
   - defaults

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -1,5 +1,5 @@
 name: HyperSpy-bundle
-version: 2020.08.13
+version: 2020.11.14
 
 install_in_dependency_order: True
 # Error: File 'lib/libiomp5.dylib' found in multiple packages: intel-openmp-2019.4-233.conda, llvm-openmp-10.0.0-h28b9765_0.conda
@@ -29,6 +29,7 @@ specs:
   - atomap
   - pyxem
   - kikuchipy
+  - mamba
 
 license_file: LICENSE
 

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -11,24 +11,24 @@ channels:
   - msys2    # [win]
 
 specs:
-  - python 3.8*
-  - conda
-  - menuinst                                # [win]
-  - console_shortcut                        # [win]
-  - spyder
   - anaconda-navigator
-  - nb_conda_kernels
+  - atomap
+  - conda
+  - console_shortcut                        # [win]
   - hyperspy >=1.6
   - hyperspyui
-  - start_jupyter_cm
   - ipympl >=0.5.7
   - jupyterlab
-  - nodejs
-  - qtconsole
-  - atomap
-  - pyxem
   - kikuchipy
   - mamba
+  - menuinst                                # [win]
+  - nb_conda_kernels
+  - nodejs
+  - python 3.8*
+  - pyxem
+  - qtconsole
+  - spyder
+  - start_jupyter_cm
 
 license_file: LICENSE
 

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -1,4 +1,4 @@
-{% set version = os.environ.get("tag", "2020.11.15") %}
+{% set version = os.environ.get("version", "2020.11.15") %}
 
 name: HyperSpy-bundle
 version: {{ version }}

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -1,13 +1,13 @@
-name: HyperSpy-bundle
-version: 2020.11.14
+{% set version = os.environ.get("tag", "2020.11.15") %}
 
-# Error: File 'lib/libiomp5.dylib' found in multiple packages: intel-openmp-2019.4-233.conda, llvm-openmp-10.0.0-h28b9765_0.conda
-# Error: File 'lib/python3.8/__pycache__/_sysconfigdata_x86_64_conda_cos6_linux_gnu.cpython-38.pyc' found in multiple packages: ujson-1.35-py38h7b6447c_0.conda, pyqt-5.9.2-py38h05f1152_4.conda, lazy-object-proxy-1.4.3-py38h7b6447c_0.conda, python-blosc-1.7.0-py38h7b6447c_0.conda, markupsafe-1.1.1-py38h7b6447c_0.conda, python-3.8.5-hcff3b4d_0.conda, pycifrw-4.4.1-py38h516909a_0.tar.bz2, wrapt-1.11.2-py38h7b6447c_0.conda, gmpy2-2.0.8-py38hd5f6e3b_3.conda, fastcache-1.1.0-py38h7b6447c_0.conda
+name: HyperSpy-bundle
+version: {{ version }}
+
 ignore_duplicate_files: True
 
 channels:
-  - defaults
   - conda-forge
+  - defaults
   - msys2    # [win]
 
 specs:
@@ -40,10 +40,10 @@ post_install: post_install.bat              # [win]
 
 pre_uninstall: pre_uninstall.bat            # [win]
 
-post_install_desc: "Don't install jupyterlab widgets and context menu shortcuts." # [win]
+post_install_desc: "Build jupyterlab widgets and add context menu shortcuts." # [win]
 
 check_path_length: True                     # [win]
-
+transmute_file_type: ".conda"
 installer_type: pkg                         # [osx]
 
 # Icon image for Windows installer

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -8,24 +8,25 @@ ignore_duplicate_files: True
 channels:
   - conda-forge
   - defaults
-  - msys2    # [win]
+  - msys2  # [win]
 
 specs:
   - anaconda-navigator
   - atomap
   - conda
-  - console_shortcut                        # [win]
-  - hyperspy >=1.6
+  - console_shortcut  # [win]
+  - hyperspy >=1.6.1
   - hyperspyui
-  - ipympl >=0.5.7
+  - ipympl
   - jupyterlab
   - kikuchipy
   - mamba
-  - menuinst                                # [win]
+  - menuinst  # [win]
   - nb_conda_kernels
   - nodejs
   - python 3.8*
   - pyxem
+  - qt !=5.12.9  # [osx]
   - qtconsole
   - spyder
   - start_jupyter_cm


### PR DESCRIPTION
- add mamba package manager
- remove deprecated `set-env` command on Github action
- remove deprecated key in `construct.yaml`
- *transmute* package to `.conda` file format to reduce installer size
- use more constructor dev branch, which includes a few bug fixes
- use tag to set the version with `constructor`
- update winpython to latest version
- update `RELEASING_GUIDE.md` and `README.md`