### PR TITLE
Set condarc and pin blas to mkl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,8 @@ jobs:
         run: |
           conda activate "${{ env.install_dir }}"
           conda info
+          conda config --show channels
+          conda config --show channel_priority
           conda list
 
       - shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
         env:
           VERSION: ${{ needs.create_release_job.outputs.VERSION }}
         run: |
+          conda config --set channel_priority strict
           constructor -v conda_distribution
 
       - shell: bash -l {0}

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -20,6 +20,7 @@ specs:
   - ipympl
   - jupyterlab
   - kikuchipy
+  - libblas=*=*mkl
   - mamba
   - menuinst  # [win]
   - nb_conda_kernels

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -3,7 +3,12 @@
 name: HyperSpy-bundle
 version: {{ version }}
 
-ignore_duplicate_files: True
+condarc:
+  channels:
+    - conda-forge
+    - defaults
+    - msys2  # [win]
+  channel_priority: strict
 
 channels:
   - conda-forge
@@ -33,8 +38,6 @@ specs:
   - start_jupyter_cm
 
 license_file: LICENSE
-
-write_condarc: True
 
 post_install: post_install.sh               # [linux]
 post_install: post_install_macosx.sh        # [osx]


### PR DESCRIPTION
- [x] Set condarc with channel priority strict to be consistent with conda-forge guideline, see
      - https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge
      - https://conda-forge.org/docs/user/faq.html?highlight=channel_priority#faq-solver-speed
- [x] pin blas to mkl (`libblas=*=*mkl`), to make sure the mkl implementation is used. See https://conda-forge.org/docs/maintainer/knowledge_base.html#switching-blas-implementation