### PR TITLE
Use conda forge only and jupyterlab 3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: ${{ env.asset_name }}
+          name: ${{ env.asset_name }}
 
       - shell: bash -l {0}
         name: Info new distribution
@@ -232,6 +233,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: ${{ env.asset_name }}
+          name: ${{ env.asset_name }}
 
       - name: Install new distribution
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,6 @@ jobs:
           - os: windows
             INSTALLER_EXTENSION: exe
     env:
-      MPLBACKEND: agg
       DISPLAY: :0
       # Remove pytest-mpl once https://github.com/hyperspy/hyperspy/pull/2624
       # is merged and released.
@@ -181,7 +180,6 @@ jobs:
       WP_SHA256: d17e9f0b837d1f9d63909ff39b7c44545b79268affd0ac848fd8f05af57745ea
       WP_EXE: winpython.exe
       WP_DIR_NAME: WPy64-3870
-      MPLBACKEND: agg
       # Remove pytest-mpl once https://github.com/hyperspy/hyperspy/pull/2624
       # is merged and released.
       TEST_DEPS: pytest pytest-mpl pytest-qt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       # Remove pytest-mpl once https://github.com/hyperspy/hyperspy/pull/2624
       # is merged and released.
       TEST_DEPS: pytest pytest-mpl pytest-qt
-      LIB_TO_TEST: hyperspy hyperspyui
+      LIB_TO_TEST: hyperspy
 
     steps:
       - uses: actions/checkout@v2
@@ -158,6 +158,7 @@ jobs:
         run: |
           conda activate "${{ env.install_dir }}"
           conda install ${{ env.TEST_DEPS }} -c conda-forge
+          pytest --pyargs hyperspyui
           pytest --pyargs ${{ env.LIB_TO_TEST }}
 
       - name: Upload Release Asset
@@ -185,7 +186,7 @@ jobs:
       TEST_DEPS: pytest pytest-mpl pytest-qt
       LIB_TO_INSTALL: hyperspy[all] hyperspyui pyxem atomap kikuchipy
       LIB_TO_UPGRADE: hyperspy
-      LIB_TO_TEST: hyperspy hyperspyui
+      LIB_TO_TEST: hyperspy
 
     steps:
       - name: Download Winpython
@@ -259,6 +260,7 @@ jobs:
         shell: cmd
         run: |
           call "${{ env.WP_DIR_NAME }}\scripts\env.bat"
+          pytest --pyargs hyperspyui
           pytest --pyargs ${{ env.LIB_TO_TEST }}
 
       - name: Upload Release Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
             INSTALLER_EXTENSION: exe
     env:
       MPLBACKEND: agg
+      # Remove pytest-mpl once https://github.com/hyperspy/hyperspy/pull/2624
+      # is merged and released.
       TEST_DEPS: pytest pytest-mpl
       LIB_TO_TEST: hyperspy
 
@@ -148,7 +150,7 @@ jobs:
         name: Test new distribution
         run: |
           conda activate "${{ env.install_dir }}"
-          conda install ${{ env.TEST_DEPS }}
+          conda install ${{ env.TEST_DEPS }} -c conda-forge
           pytest --pyargs ${{ env.LIB_TO_TEST }}
 
       - name: Upload Release Asset
@@ -172,7 +174,9 @@ jobs:
       WP_EXE: winpython.exe
       WP_DIR_NAME: WPy64-3870
       MPLBACKEND: agg
-      TEST_DEPS: pytest
+      # Remove pytest-mpl once https://github.com/hyperspy/hyperspy/pull/2624
+      # is merged and released.
+      TEST_DEPS: pytest pytest-mpl
       LIB_TO_INSTALL: hyperspy[all] hyperspyui pyxem atomap kikuchipy
       LIB_TO_UPGRADE: hyperspy
       LIB_TO_TEST: hyperspy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,11 @@ jobs:
             INSTALLER_EXTENSION: exe
     env:
       MPLBACKEND: agg
+      DISPLAY: :0
       # Remove pytest-mpl once https://github.com/hyperspy/hyperspy/pull/2624
       # is merged and released.
-      TEST_DEPS: pytest pytest-mpl
-      LIB_TO_TEST: hyperspy
+      TEST_DEPS: pytest pytest-mpl pytest-qt
+      LIB_TO_TEST: hyperspy hyperspyui
 
     steps:
       - uses: actions/checkout@v2
@@ -147,6 +148,12 @@ jobs:
           conda config --show channel_priority
           conda list
 
+      - name: Install and Start xvfb
+        if: runner.os == 'linux'
+        run: |
+          sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
+          sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 & 
+
       - shell: bash -l {0}
         name: Test new distribution
         run: |
@@ -177,10 +184,10 @@ jobs:
       MPLBACKEND: agg
       # Remove pytest-mpl once https://github.com/hyperspy/hyperspy/pull/2624
       # is merged and released.
-      TEST_DEPS: pytest pytest-mpl
+      TEST_DEPS: pytest pytest-mpl pytest-qt
       LIB_TO_INSTALL: hyperspy[all] hyperspyui pyxem atomap kikuchipy
       LIB_TO_UPGRADE: hyperspy
-      LIB_TO_TEST: hyperspy
+      LIB_TO_TEST: hyperspy hyperspyui
 
     steps:
       - name: Download Winpython

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,14 +167,12 @@ jobs:
     needs: create_release_job
     runs-on: windows-latest
     env:
-      WP_URL: https://github.com/winpython/winpython/releases/download/3.0.20201028/Winpython64-3.8.6.0cod.exe
-      WP_SHA256: d1457a5732825d0717f54e45e9d1f8ea890974e317d0b797a99b5d70b59d6839
+      WP_URL: https://github.com/winpython/winpython/releases/download/3.0.202011219/Winpython64-3.8.7.0cod.exe
+      WP_SHA256: d17e9f0b837d1f9d63909ff39b7c44545b79268affd0ac848fd8f05af57745ea
       WP_EXE: winpython.exe
-      WP_DIR_NAME: WPy64-3860
+      WP_DIR_NAME: WPy64-3870
       MPLBACKEND: agg
-      # remove `pytest-tornasync` test dependency when more recent jupyter_server is available
-      # https://github.com/jupyter-server/jupyter_server/issues/337
-      TEST_DEPS: pytest pytest-mpl pytest-tornasync
+      TEST_DEPS: pytest
       LIB_TO_INSTALL: hyperspy[all] hyperspyui pyxem atomap kikuchipy
       LIB_TO_UPGRADE: hyperspy
       LIB_TO_TEST: hyperspy
@@ -200,8 +198,8 @@ jobs:
           call "${{ env.WP_DIR_NAME }}\scripts\env.bat"
           where python
           where pip
-          pip install --use-feature=2020-resolver ${{ env.LIB_TO_INSTALL }}
-          pip install --upgrade --use-feature=2020-resolver ${{ env.LIB_TO_UPGRADE }}
+          pip install ${{ env.LIB_TO_INSTALL }}
+          pip install --upgrade ${{ env.LIB_TO_UPGRADE }}
 
       - shell: bash -l {0}
         name: Set installer name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,10 +158,17 @@ jobs:
           sudo /usr/bin/Xvfb ${{ env.DISPLAY }} -screen 0 1280x1024x24 & 
 
       - shell: bash -l {0}
-        name: Test new distribution (HyperSpyUI)
+        name: Install test dependencies
         run: |
           conda activate "${{ env.install_dir }}"
           conda install ${{ env.TEST_DEPS }} -c conda-forge
+
+      - shell: bash -l {0}
+        # TODO: revisit at some point, to get it to work on linux (hyperspyui CI works fine...)
+        if: runner.os != 'linux'
+        name: Test new distribution (HyperSpyUI)
+        run: |
+          conda activate "${{ env.install_dir }}"
           pytest --pyargs hyperspyui
 
       - shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,11 @@ jobs:
           - os: windows
             INSTALLER_EXTENSION: exe
     env:
-      DISPLAY: :0
       # Remove pytest-mpl once https://github.com/hyperspy/hyperspy/pull/2624
       # is merged and released.
       TEST_DEPS: pytest pytest-mpl pytest-qt
       LIB_TO_TEST: hyperspy
+      DISPLAY: :0
 
     steps:
       - uses: actions/checkout@v2
@@ -147,18 +147,29 @@ jobs:
           conda config --show channel_priority
           conda list
 
-      - name: Install and Start xvfb
+      - name: Install xvfb
         if: runner.os == 'linux'
         run: |
           sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
-          sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 & 
+
+      - name: Start xvfb
+        if: runner.os == 'linux'
+        run: |
+          sudo /usr/bin/Xvfb ${{ env.DISPLAY }} -screen 0 1280x1024x24 & 
 
       - shell: bash -l {0}
-        name: Test new distribution
+        name: Test new distribution (HyperSpyUI)
         run: |
           conda activate "${{ env.install_dir }}"
           conda install ${{ env.TEST_DEPS }} -c conda-forge
           pytest --pyargs hyperspyui
+
+      - shell: bash -l {0}
+        name: Test new distribution
+        env:
+          MPLBACKEND: 'agg'
+        run: |
+          conda activate "${{ env.install_dir }}"
           pytest --pyargs ${{ env.LIB_TO_TEST }}
 
       - name: Upload Release Asset
@@ -256,11 +267,18 @@ jobs:
           call "${{ env.WP_DIR_NAME }}\scripts\env.bat"
           pip install ${{ env.TEST_DEPS }}
 
-      - name: Run test suite
+      - name: Run test suite (HyperSpyUI)
         shell: cmd
         run: |
           call "${{ env.WP_DIR_NAME }}\scripts\env.bat"
           pytest --pyargs hyperspyui
+
+      - name: Run test suite
+        shell: cmd
+        env:
+          MPLBACKEND: 'agg'
+        run: |
+          call "${{ env.WP_DIR_NAME }}\scripts\env.bat"
           pytest --pyargs ${{ env.LIB_TO_TEST }}
 
       - name: Upload Release Asset

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -23,13 +23,12 @@ specs:
   - hyperspy >=1.6.1
   - hyperspyui
   - ipympl
-  - jupyterlab
+  - jupyterlab >=3.0.0
   - kikuchipy
   - libblas=*=*mkl
   - mamba
   - menuinst  # [win]
   - nb_conda_kernels
-  - nodejs
   - python 3.8*
   - pyxem >=0.12.3
   - qt !=5.12.9  # [osx]
@@ -45,9 +44,8 @@ post_install: post_install.bat              # [win]
 
 pre_uninstall: pre_uninstall.bat            # [win]
 
-post_install_desc: "Build jupyterlab widgets and add context menu shortcuts." # [win]
+post_install_desc: "Add context menu shortcuts." # [win]
 
-check_path_length: True                     # [win]
 transmute_file_type: ".conda"
 installer_type: pkg                         # [osx]
 

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -4,22 +4,15 @@ name: HyperSpy-bundle
 version: {{ version }}
 
 condarc:
-  channels:
-    - conda-forge
-    - defaults
-    - msys2  # [win]
-  channel_priority: strict
+  pinned_packages:
+    - libblas=*=*mkl
 
 channels:
   - conda-forge
-  - defaults
-  - msys2  # [win]
 
 specs:
-  - anaconda-navigator
   - atomap
   - conda
-  - console_shortcut  # [win]
   - hyperspy >=1.6.1
   - hyperspyui
   - ipympl
@@ -27,11 +20,12 @@ specs:
   - kikuchipy
   - libblas=*=*mkl
   - mamba
-  - menuinst  # [win]
+  - miniforge_console_shortcut  # [win]
+  - notebook
   - nb_conda_kernels
   - python 3.8*
-  - pyxem >=0.12.3
-  - qt !=5.12.9  # [osx]
+  - pyxem
+  - qt
   - qtconsole
   - spyder
   - start_jupyter_cm

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -4,6 +4,8 @@ name: HyperSpy-bundle
 version: {{ version }}
 
 condarc:
+  channels:
+    - conda-forge
   pinned_packages:
     - libblas=*=*mkl
 

--- a/conda_distribution/construct.yaml
+++ b/conda_distribution/construct.yaml
@@ -16,17 +16,17 @@ specs:
   - atomap
   - conda
   - hyperspy >=1.6.1
-  - hyperspyui
+  - hyperspyui >=1.1.3
   - ipympl
   - jupyterlab >=3.0.0
-  - kikuchipy
+  - kikuchipy >=0.3.1
   - libblas=*=*mkl
   - mamba
   - miniforge_console_shortcut  # [win]
   - notebook
   - nb_conda_kernels
   - python 3.8*
-  - pyxem
+  - pyxem >=0.13.0
   - qt
   - qtconsole
   - spyder

--- a/conda_distribution/post_install.bat
+++ b/conda_distribution/post_install.bat
@@ -6,8 +6,3 @@ call %PREFIX%\\Scripts\\activate.bat
 :: Add context menu
 start_jupyter_cm
 
-:: Installing the JupyterLab Extension
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
-
-:: Add nionswift desktop shortcut
-::nionswift --alias

--- a/conda_distribution/post_install.sh
+++ b/conda_distribution/post_install.sh
@@ -8,7 +8,4 @@ source ${PREFIX}/bin/activate base
 # Desktop integration
 start_jupyter_cm
 
-# Installing the JupyterLab Extension
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
-
 echo "Post install script completed!"

--- a/conda_distribution/post_install_macosx.sh
+++ b/conda_distribution/post_install_macosx.sh
@@ -13,7 +13,4 @@ source ${PREFIX}/bin/activate base
 # Desktop integration
 start_jupyter_cm
 
-# Installing the JupyterLab Extension
-jupyter labextension install @jupyter-widgets/jupyterlab-manager
-
 echo "Post install script completed!"


### PR DESCRIPTION
- Use conda-forge only:
  - now that `conda-forge` is fully independent from anaconda `defaults` channels on all platforms, remove `defaults` to simplify updating environment
  - now completely aligned with the conda-forge eco-system
- set `condarc` file in `ROOT_PREFIX` during installation: if the user doesn't already have a `condarc` file or as long as the user doesn't overwrite the setting, the setting of the `condarc` defined in `construct.yaml` will be used. Setting additional channel after the installation will add the `defaults` channel and this is fixed by https://github.com/conda/conda/pull/10479. 
- Jupyterlab 3: building extension are not required anymore
   - remove `nodejs` (avoid issue with long path on windows)
   - remove building extension in post-install scripts (faster)
   - update post-install scripts description accordingly
- run test hyperspyui test suite (except on Linux, which needs to be fixed)
- update each artefacts separately on CI.