### PR TITLE
Remove deprecated actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           find: "__TAG__"
           replace: ${{ env.VERSION }}
           include: "RELEASE_TEXT.md" # Will match all RELEASE_TEXT.md files in any nested directory
-          
+
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         id: create_release
@@ -57,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
         with:
           body_path: "RELEASE_TEXT.md"
-          draft: true
+          prerelease: true
 
 
   build:
@@ -227,7 +227,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: ${{ env.asset_name }}
-          draft: true
+          prerelease: true
 
 
   build_portable:
@@ -347,7 +347,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: ${{ env.asset_name }}
-          draft: true
+          prerelease: true
 
 
   finalise_release_job:
@@ -361,5 +361,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
         with:
-          draft: false
+          prerelease: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,22 @@ jobs:
       VERSION: ${{ env.VERSION }}
     steps:
       - uses: actions/checkout@v2
+
       - name: Get version (on tag)
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Get version (short hash)
         if: "!startsWith(github.ref, 'refs/tags/')"
         run: |
           # Use git short hash instead of tag
           echo "VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Display version
         run: |
           echo ${{ env.VERSION }}
+
       - name: Find and Replace
         uses: jacobtomlinson/gha-find-replace@master
         if: startsWith(github.ref, 'refs/tags/')
@@ -44,18 +48,17 @@ jobs:
           find: "__TAG__"
           replace: ${{ env.VERSION }}
           include: "RELEASE_TEXT.md" # Will match all RELEASE_TEXT.md files in any nested directory
+          
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
           body_path: "RELEASE_TEXT.md"
-          draft: false
-          prerelease: false
+          draft: true
+
 
   build:
     name: ${{ matrix.os }}-${{ matrix.BLAS_IMPL }}
@@ -219,14 +222,13 @@ jobs:
 
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.create_release_job.outputs.upload_url }}
-          asset_path: ./${{ env.asset_name }}
-          asset_name: ${{ env.asset_name }}
-          asset_content_type: application/zip
+          files: ${{ env.asset_name }}
+          draft: true
+
 
   build_portable:
     name: windows (Portable)
@@ -340,12 +342,24 @@ jobs:
 
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.create_release_job.outputs.upload_url }}
-          asset_path: ./${{ env.asset_name }}
-          asset_name: ${{ env.asset_name }}
-          asset_content_type: application/zip
+          files: ${{ env.asset_name }}
+          draft: true
+
+
+  finalise_release_job:
+    needs: [build, build_portable]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalise release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        with:
+          draft: false
 


### PR DESCRIPTION
- Switch from deprecated official github action to softprops/action-gh-release
- Mark the release as `pre-release` until all artifacts have been uploaded. 