### PR TITLE
Pin actions and fix pyfai installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,6 @@ jobs:
       WP_DIR_NAME: WPy64-3950
       TEST_DEPS: pytest pytest-qt
       LIB_TO_INSTALL: hyperspy[all] hyperspyui pyxem atomap kikuchipy pystackreg matplotlib-scalebar start_jupyter_cm particlespy nglview scanning_drift_corr
-      LIB_TO_UPGRADE: hyperspy
       LIB_TO_TEST: atomap pyxem kikuchipy
 
     steps:
@@ -273,7 +272,6 @@ jobs:
           # https://github.com/silx-kit/pyFAI/issues/1537
           pip install pyfai==0.20 numpy==1.21.0 --no-binary pyfai --no-build-isolation
           pip install ${{ env.LIB_TO_INSTALL }}
-          pip install --upgrade ${{ env.LIB_TO_UPGRADE }}
 
       - shell: bash -l {0}
         name: Set installer name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,6 +269,9 @@ jobs:
           where pip
           # pin dask until https://github.com/dask/dask/issues/7583 is fixed
           pip install dask==2021.3.1 distributed==2021.3.1
+          # pyfai 0.20 is built against numpy 1.21.1
+          # https://github.com/silx-kit/pyFAI/issues/1537
+          pip install pyfai==0.20 numpy==1.21.0 --no-binary pyfai --no-build-isolation
           pip install ${{ env.LIB_TO_INSTALL }}
           pip install --upgrade ${{ env.LIB_TO_UPGRADE }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
       - '*'
   pull_request:
     branches:
-      - master
+      - main
 
 permissions:
   # needs write permission at workflow level to create release and upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           echo ${{ env.VERSION }}
 
       - name: Find and Replace
-        uses: jacobtomlinson/gha-find-replace@master
+        uses: jacobtomlinson/gha-find-replace@0.1.4
         if: startsWith(github.ref, 'refs/tags/')
         with:
           find: "__TAG__"
@@ -52,7 +52,7 @@ jobs:
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
         with:
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -342,7 +342,7 @@ jobs:
 
       - name: Upload Release Asset
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
- [x] Now that dependabot is setup in this github repository, we can pin github actions.
- [x] Workaround for the numpy requirement for pyfai. pyfai needs to be build from source because otherwise it will upgrade numpy in winpython, which will in turn breaks winpython. Fixed in https://github.com/silx-kit/pyFAI/issues/1537.